### PR TITLE
[CLEANUP] Drop obsolete dividers2tabs from the TCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop obsolete `dividers2tabs` from the TCA (#44)
 - Drop obsolete parts from the README (#34)
 - Drop unneeded Travis CI configuration settings
 - Drop `ext_icon.svg`

--- a/Configuration/TCA/tx_tea_domain_model_product_tea.php
+++ b/Configuration/TCA/tx_tea_domain_model_product_tea.php
@@ -8,7 +8,6 @@ $tca = [
         'cruser_id' => 'cruser_id',
         'delete' => 'deleted',
         'default_sortby' => 'title',
-        'dividers2tabs' => true,
         'iconfile' => 'EXT:tea/Resources/Public/Icons/Record.svg',
         'searchFields' => 'title, description',
     ],


### PR DESCRIPTION
This option has been removed in TYPO3 7.

Resolves #43