### PR TITLE
[TASK] Update the GitHub actions status badge URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Composer script for PHP linting
 
 ### Changed
+- Move the project to the TYPO3 Documentation Team (#47)
 - Run unit tests with GitHub actions (#37)
 - Switch from PSR-2 to PSR-12 (#3, #35)
 - Move TypoScript linting to GitHub actions (#14)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tea example
 
 [![Build Status](https://travis-ci.org/typo3-trainer-network/tea.svg?branch=master)](https://travis-ci.org/typo3-trainer-network/tea)
-[![CI Status](https://github.com/typo3-trainer-network/tea/workflows/CI/badge.svg)](https://github.com/typo3-trainer-network/tea/actions)
+[![CI Status](https://github.com/TYPO3-Documentation/tea/workflows/CI/badge.svg)](https://github.com/TYPO3-Documentation/tea/actions)
 [![Latest Stable Version](https://poser.pugx.org/ttn/tea/v/stable.svg)](https://packagist.org/packages/ttn/tea)
 [![Total Downloads](https://poser.pugx.org/ttn/tea/downloads.svg)](https://packagist.org/packages/ttn/tea)
 [![Latest Unstable Version](https://poser.pugx.org/ttn/tea/v/unstable.svg)](https://packagist.org/packages/ttn/tea)


### PR DESCRIPTION
Now that the project has been moved to a different project,
the GitHub actions status badge URL needs to be adapted.