### PR TITLE
[BUGFIX] Use the PHP version from the matrix in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+
     - name: Run PHP lint
       run: composer ci:php:lint
 
@@ -29,9 +34,19 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php-version:
+          - 7.3
+
     steps:
     - name: Checkout
       uses: actions/checkout@v1
+
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
 
     - name: "Cache dependencies installed with composer"
       uses: actions/cache@v1
@@ -52,9 +67,19 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php-version:
+          - 7.3
+
     steps:
     - name: Checkout
       uses: actions/checkout@v1
+
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
 
     - name: "Cache dependencies installed with composer"
       uses: actions/cache@v1
@@ -91,6 +116,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
+
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
 
     - name: "Cache dependencies installed with composer"
       uses: actions/cache@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the dependency of `roave/security-advisories`
 
 ### Fixed
+- Use the PHP version from the matrix in the CI (#48)
 - Re-add the static TypoScript registration (#41)
 - Keep the global namespace clean in `ext_localconf.php` (#40)
 - Update the badge URLs in the `README` (#29, #22)


### PR DESCRIPTION
For GitHub actions, an explicit step is required to use a
specific PHP version. If this is not done, a default version
will be used (which makes the builds unpredictable).