### PR TITLE
[BUGFIX] Avoid unwanted higher PHP versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the dependency of `roave/security-advisories`
 
 ### Fixed
+- Avoid unwanted higher PHP versions (#50)
 - Stop caching `vendor/` on Travis CI (#51)
 - Use the PHP version from the matrix in the CI (#48)
 - Re-add the static TypoScript registration (#41)

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "source": "https://github.com/typo3-trainer-network/tea"
     },
     "require": {
-        "php": "~7.2 || ~7.3 || ~7.4",
+        "php": "~7.2.0 || ~7.3.0 || ~7.4.0",
         "typo3/cms-core": "^9.5.4 || ^10.2",
         "typo3/cms-extbase": "^9.5 || ^10.2",
         "typo3/cms-fluid": "^9.5 || ^10.2",


### PR DESCRIPTION
To avoid stating any untested compatibility with a (non-existent) PHP
version 7.5, the requirements in the `composer.json` need to provide
the patch-level version as well as `~7.0` works the same as `^7.0`,
while `~7.0.0` does not.