### PR TITLE
[BUGFIX] Stop caching vendor/ on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
 
 cache:
   directories:
-  - .Build/vendor
   - $HOME/.composer/cache
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the dependency of `roave/security-advisories`
 
 ### Fixed
+- Stop caching `vendor/` on Travis CI (#51)
 - Use the PHP version from the matrix in the CI (#48)
 - Re-add the static TypoScript registration (#41)
 - Keep the global namespace clean in `ext_localconf.php` (#40)


### PR DESCRIPTION
Downgrades of Composer packages do not work reliably
if a higher version of a package already is installed in `vendor/`.
This causes builds to use higher versions of packages than intended
if Travis CI has the corresponding version in the cached and restored
`vendor/` folder.