### PR TITLE
[TASK] Disable running with lower dependencies on GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           #- "^10.2"
         composer-dependencies:
           - highest
-          - lowest
+#          - lowest
         php-version:
           - 7.2
           - 7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Composer script for PHP linting
 
 ### Changed
+- Disable running with lower dependencies on GitHub actions (#54)
 - Move the project to the TYPO3 Documentation Team (#47)
 - Run unit tests with GitHub actions (#37)
 - Switch from PSR-2 to PSR-12 (#3, #35)


### PR DESCRIPTION
This currently is broken, and we need to find the cause and fix it
first.

In the meantime, disable this so the build is green again.