### PR TITLE
[TASK] Set reflection docblock version to avoid bug in package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "phpunit/phpunit": "^7.5.20",
         "squizlabs/php_codesniffer": "^3.5.5",
         "typo3/cms-fluid-styled-content": "^9.5 || 10.4",
-        "seld/jsonlint": "^1.8"
+        "seld/jsonlint": "^1.8",
+        "phpdocumentor/reflection-docblock": "<= 5.1 || > 5.2"
     },
     "replace": {
         "typo3-ter/tea": "self.version"


### PR DESCRIPTION
There is a bug in reflection-docblock package in version 5.2.0. This version of package breaks functional tests. We have to wait for T3 bugfix.