### PR TITLE
[TASK] Smoothen the way to Composer 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+      - name: "Show Composer version"
+        run: composer --version
       -
         name: "Cache dependencies installed with composer"
         uses: actions/cache@v1
@@ -112,6 +114,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+      - name: "Show Composer version"
+        run: composer --version
       -
         name: "Cache dependencies installed with composer"
         uses: actions/cache@v1
@@ -132,13 +136,13 @@ jobs:
         name: "Install lowest dependencies with composer"
         run: |
           composer update --no-ansi --no-interaction |
-          --no-progress --no-suggest --prefer-lowest
+          --no-progress --prefer-lowest
           composer show
       -
         if: "matrix.composer-dependencies == 'highest'"
         name: "Install highest dependencies with composer"
         run: |
-          composer update --no-ansi --no-interaction --no-progress --no-suggest
+          composer update --no-ansi --no-interaction --no-progress
           composer show
       -
         name: "Run unit tests"
@@ -167,6 +171,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+      - name: "Show Composer version"
+        run: composer --version
       -
         name: "Cache dependencies installed with composer"
         uses: actions/cache@v1
@@ -187,13 +193,13 @@ jobs:
         name: "Install lowest dependencies with composer"
         run: |
           composer update --no-ansi --no-interaction |
-          --no-progress --no-suggest --prefer-lowest
+          --no-progress --prefer-lowest
           composer show
       -
         if: "matrix.composer-dependencies == 'highest'"
         name: "Install highest dependencies with composer"
         run: |
-          composer update --no-ansi --no-interaction --no-progress --no-suggest
+          composer update --no-ansi --no-interaction --no-progress
           composer show
       -
         name: "Start MySQL"

--- a/.gitlab/pipeline/.gitlab-ci.yml
+++ b/.gitlab/pipeline/.gitlab-ci.yml
@@ -28,6 +28,7 @@ build-composer-dependencies:
   variables:
     COMPOSER_CACHE_DIR: '.composer'
   script:
+    - composer --version
     - COMPOSER_CACHE_DIR=.composer
       composer install --prefer-dist --no-progress --optimize-autoloader
   artifacts:


### PR DESCRIPTION
- drop the `--no-suggest` option that was deprecated in Composer 2
- output the Composer version to make debugging problems easier