### PR TITLE
Migrate secret detection in gitlab ci

### DIFF
--- a/.gitlab/pipeline/.gitlab-ci.yml
+++ b/.gitlab/pipeline/.gitlab-ci.yml
@@ -128,6 +128,7 @@ func-php7.2-v10:
     - build-composer-dependencies
     - php-lint-php7.2
   script:
+    - composer require typo3/minimal:"^10.4"
     - composer ci:tests:functional
 
 func-php7.3-v10:
@@ -139,6 +140,7 @@ func-php7.3-v10:
     - build-composer-dependencies
     - php-lint-php7.3
   script:
+    - composer require typo3/minimal:"^10.4"
     - composer ci:tests:functional
 
 func-php7.4-v10:
@@ -150,6 +152,7 @@ func-php7.4-v10:
     - build-composer-dependencies
     - php-lint-php7.4
   script:
+    - composer require typo3/minimal:"^10.4"
     - composer ci:tests:functional
 
 unit-php7.2-v9:

--- a/.gitlab/pipeline/.gitlab-ci.yml
+++ b/.gitlab/pipeline/.gitlab-ci.yml
@@ -243,5 +243,5 @@ eslint-sast:
 phpcs-security-audit-sast:
   before_script: []
 
-secrets-sast:
+secret_detection:
   before_script: []

--- a/.gitlab/pipeline/.gitlab-ci.yml
+++ b/.gitlab/pipeline/.gitlab-ci.yml
@@ -109,6 +109,7 @@ unit-php7.3-v10:
     - build-composer-dependencies
     - php-lint-php7.3
   script:
+    - composer require typo3/minimal:"^10.4"
     - composer ci:tests:unit
 
 unit-php7.4-v10:
@@ -118,6 +119,7 @@ unit-php7.4-v10:
     - build-composer-dependencies
     - php-lint-php7.4
   script:
+    - composer require typo3/minimal:"^10.4"
     - composer ci:tests:unit
 
 func-php7.2-v10:
@@ -141,6 +143,7 @@ func-php7.3-v10:
     - build-composer-dependencies
     - php-lint-php7.3
   script:
+    - composer require typo3/minimal:"^10.4"
     - composer ci:tests:functional
 
 func-php7.4-v10:
@@ -152,6 +155,7 @@ func-php7.4-v10:
     - build-composer-dependencies
     - php-lint-php7.4
   script:
+    - composer require typo3/minimal:"^10.4"
     - composer ci:tests:functional
 
 unit-php7.2-v9:

--- a/.gitlab/pipeline/.gitlab-ci.yml
+++ b/.gitlab/pipeline/.gitlab-ci.yml
@@ -7,6 +7,7 @@ stages:
 
 include:
   - template: License-Management.gitlab-ci.yml
+  - template: Secret-Detection.gitlab-ci.yml
   - template: SAST.gitlab-ci.yml
   - template: Code-Quality.gitlab-ci.yml
 

--- a/.gitlab/pipeline/.gitlab-ci.yml
+++ b/.gitlab/pipeline/.gitlab-ci.yml
@@ -99,6 +99,7 @@ unit-php7.2-v10:
     - build-composer-dependencies
     - php-lint-php7.2
   script:
+    - composer require typo3/minimal:"^10.4"
     - composer ci:tests:unit
 
 unit-php7.3-v10:
@@ -140,7 +141,6 @@ func-php7.3-v10:
     - build-composer-dependencies
     - php-lint-php7.3
   script:
-    - composer require typo3/minimal:"^10.4"
     - composer ci:tests:functional
 
 func-php7.4-v10:
@@ -152,7 +152,6 @@ func-php7.4-v10:
     - build-composer-dependencies
     - php-lint-php7.4
   script:
-    - composer require typo3/minimal:"^10.4"
     - composer ci:tests:functional
 
 unit-php7.2-v9:


### PR DESCRIPTION
secrets-sast was removed from SAST vendored template
https://gitlab.com/gitlab-org/gitlab/-/issues/234011

we need to migrate to separate template, it's breaking gitlab ci template ATM, as it's moved out and it won't work anymore