### PR TITLE
[FEATURE] Also run the CI build once a week

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '15 3 * * 1'
 jobs:
   php-lint:
     name: "PHP linter"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Also run the CI build once a week (#160)
 - Run the functional tests via GitHub Actions (#55)
 - Cache Composer dependencies in build (#31)
 - Add a status badge for GitHub actions (#32)


### PR DESCRIPTION
This will allow us to catch problems with dependencies or
the build environment, i.e., problems that are not related
to changes in our code base.