### PR TITLE
[BUGFIX] Explicitly set the Ubuntu version for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           - ^10.4
   functional-tests:
     name: "Functional tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: php-lint
     steps:
       -
@@ -178,6 +178,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           tools: composer:v2
+          extensions: mysqli
       - name: "Show Composer version"
         run: composer --version
       -


### PR DESCRIPTION
This fixes a warning when running the CI build.

As the functional tests currently do not run with the Ubuntu 20.04
runner, we need to keep using 18.04.
    
Also explicitly require the `mysqli` PHP extension.