### PR TITLE
[BUGFIX] Stop treating *.ts files as TypoScript in the .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -50,7 +50,7 @@ indent_style = space
 indent_size = 3
 
 # TypoScript-Files
-[*.typoscript,*.ts]
+[*.typoscript]
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
`*.ts` are TypeScript files, not TypoScript files.