### PR TITLE
[BUGFIX] Fix the CI build with the lowest dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,14 +138,13 @@ jobs:
         if: "matrix.composer-dependencies == 'lowest'"
         name: "Install lowest dependencies with composer"
         run: |
-          composer update --no-ansi --no-interaction |
-          --no-progress --prefer-lowest
+          composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
           composer show
       -
         if: "matrix.composer-dependencies == 'highest'"
         name: "Install highest dependencies with composer"
         run: |
-          composer update --no-ansi --no-interaction --no-progress
+          composer update --no-ansi --no-interaction --no-progress --with-dependencies
           composer show
       -
         name: "Run unit tests"
@@ -154,6 +153,7 @@ jobs:
       matrix:
         composer-dependencies:
           - highest
+          - lowest
         php-version:
           - 7.2
           - 7.3
@@ -195,14 +195,13 @@ jobs:
         if: "matrix.composer-dependencies == 'lowest'"
         name: "Install lowest dependencies with composer"
         run: |
-          composer update --no-ansi --no-interaction |
-          --no-progress --prefer-lowest
+          composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
           composer show
       -
         if: "matrix.composer-dependencies == 'highest'"
         name: "Install highest dependencies with composer"
         run: |
-          composer update --no-ansi --no-interaction --no-progress
+          composer update --no-ansi --no-interaction --no-progress --with-dependencies
           composer show
       -
         name: "Start MySQL"
@@ -219,6 +218,7 @@ jobs:
       matrix:
         composer-dependencies:
           - highest
+          - lowest
         php-version:
           - 7.2
           - 7.3

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "codeception/codeception": "^4.1.5",
         "friendsofphp/php-cs-fixer": "^2.16.3",
-        "helhum/typo3-composer-setup": "^0.5.6",
+        "helhum/typo3-composer-setup": "^0.5.7",
         "helmich/typo3-typoscript-lint": "^2.1.1",
         "nimut/testing-framework": "^5.0.3",
         "phpunit/phpunit": "^7.5.20",
@@ -44,6 +44,9 @@
         "phpdocumentor/reflection-docblock": "<= 5.1 || > 5.2",
         "j13k/yaml-lint": "1.1.x-dev",
         "sebastian/phpcpd": "^4.1.0"
+    },
+    "conflict": {
+        "typo3/class-alias-loader": "< 1.1.0"
     },
     "replace": {
         "typo3-ter/tea": "self.version"


### PR DESCRIPTION
- fix a syntax error in the `ci.yml`
- also update/downgrade transitive dependencies
- add a conflict with broken versions of typo3/class-alias-loader
- use a Composer-2-compatible version of `helhum/typo3-composer-setup`
- start running the unit and functional tests with the lowest
  dependencies on GitHub Actions

Fixes #50