### PR TITLE
[CLEANUP] Adapt the TypoScript lint settings to the .editorconfig set…

### DIFF
--- a/Configuration/TsLint.yml
+++ b/Configuration/TsLint.yml
@@ -4,7 +4,7 @@ sniffs:
     class: Indentation
     parameters:
       indentConditions: true
-      indentPerLevel: 4
+      indentPerLevel: 2
       useSpaces: true
   -
     class: DeadCode

--- a/Configuration/TypoScript/Frontend/setup.typoscript
+++ b/Configuration/TypoScript/Frontend/setup.typoscript
@@ -1,8 +1,9 @@
 page {
-    includeCSS {
-        tea = EXT:tea/Resources/Public/Css/Main.css
-    }
-    includeJSFooter {
-        tea = EXT:tea/Resources/Public/JavaScript/Main.js
-    }
+  includeCSS {
+    tea = EXT:tea/Resources/Public/Css/Main.css
+  }
+
+  includeJSFooter {
+    tea = EXT:tea/Resources/Public/JavaScript/Main.js
+  }
 }

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -1,22 +1,22 @@
 plugin.tx_tea {
-    view {
-        # cat=plugin.tx_tea/file; type=string; label=Path to template root (FE)
-        templateRootPath = EXT:tea/Resources/Private/Templates/
-        # cat=plugin.tx_tea/file; type=string; label=Path to template partials (FE)
-        partialRootPath = EXT:tea/Resources/Private/Partials/
-        # cat=plugin.tx_tea/file; type=string; label=Path to template layouts (FE)
-        layoutRootPath = EXT:tea/Resources/Private/Layouts/
-    }
+  view {
+    # cat=plugin.tx_tea/file; type=string; label=Path to template root (FE)
+    templateRootPath = EXT:tea/Resources/Private/Templates/
+    # cat=plugin.tx_tea/file; type=string; label=Path to template partials (FE)
+    partialRootPath = EXT:tea/Resources/Private/Partials/
+    # cat=plugin.tx_tea/file; type=string; label=Path to template layouts (FE)
+    layoutRootPath = EXT:tea/Resources/Private/Layouts/
+  }
 
-    persistence {
-        # cat=plugin.tx_tea//a; type=string; label=Default storage PID
-        storagePid =
-        # cat=plugin.tx_tea//a; type=int; label=UID of the page/folder where all new records will be created
-        newRecordStoragePid =
-    }
+  persistence {
+    # cat=plugin.tx_tea//a; type=string; label=Default storage PID
+    storagePid =
+    # cat=plugin.tx_tea//a; type=int; label=UID of the page/folder where all new records will be created
+    newRecordStoragePid =
+  }
 
-    settings {
-        # cat=plugin.tx_tea//a; type=int; label=UID of the page with the single view
-        singleViewPageUid =
-    }
+  settings {
+    # cat=plugin.tx_tea//a; type=int; label=UID of the page with the single view
+    singleViewPageUid =
+  }
 }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,15 +1,15 @@
 plugin.tx_tea {
-    view {
-        templateRootPath = {$plugin.tx_tea.view.templateRootPath}
-        partialRootPath = {$plugin.tx_tea.view.partialRootPath}
-        layoutRootPath = {$plugin.tx_tea.view.layoutRootPath}
-    }
+  view {
+    templateRootPath = {$plugin.tx_tea.view.templateRootPath}
+    partialRootPath = {$plugin.tx_tea.view.partialRootPath}
+    layoutRootPath = {$plugin.tx_tea.view.layoutRootPath}
+  }
 
-    persistence {
-        storagePid = {$plugin.tx_tea.persistence.storagePid}
-    }
+  persistence {
+    storagePid = {$plugin.tx_tea.persistence.storagePid}
+  }
 
-    settings {
-        singleViewPageUid = {$plugin.tx_tea.settings.singleViewPageUid}
-    }
+  settings {
+    singleViewPageUid = {$plugin.tx_tea.settings.singleViewPageUid}
+  }
 }


### PR DESCRIPTION
…tings

Like in the Core, TypoScript needs to be indented with 2 spaces, not
4 spaces.

Also reformat the TypoScript files accordingly.