### PR TITLE
[CLEANUP] Sort the requirements in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,14 +36,14 @@
 		"friendsofphp/php-cs-fixer": "^2.16.3",
 		"helhum/typo3-composer-setup": "^0.5.7",
 		"helmich/typo3-typoscript-lint": "^2.1.1",
-		"nimut/testing-framework": "^5.0.3",
-		"phpunit/phpunit": "^7.5.20",
-		"squizlabs/php_codesniffer": "^3.5.5",
-		"typo3/cms-fluid-styled-content": "^9.5 || ^10.4",
-		"seld/jsonlint": "^1.8",
-		"phpdocumentor/reflection-docblock": "<= 5.1 || > 5.2",
 		"j13k/yaml-lint": "1.1.x-dev",
-		"sebastian/phpcpd": "^4.1.0"
+		"nimut/testing-framework": "^5.0.3",
+		"phpdocumentor/reflection-docblock": "<= 5.1 || > 5.2",
+		"phpunit/phpunit": "^7.5.20",
+		"sebastian/phpcpd": "^4.1.0",
+		"seld/jsonlint": "^1.8",
+		"squizlabs/php_codesniffer": "^3.5.5",
+		"typo3/cms-fluid-styled-content": "^9.5 || ^10.4"
 	},
 	"conflict": {
 		"typo3/class-alias-loader": "< 1.1.0"


### PR DESCRIPTION
This will reduce unrelated changes when requiring new packages
(as the `composer.json` is configured to keep the requirements
sorted).