### PR TITLE
[BUGFIX] Disable Xdebug in the CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          coverage: none
           tools: composer:v2
       - name: "Run PHP lint"
         run: "composer ci:php:lint"
@@ -39,6 +40,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          coverage: none
           tools: composer:v2
       - name: "Show Composer version"
         run: composer --version
@@ -104,6 +106,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          coverage: none
           tools: composer:v2
       - name: "Show Composer version"
         run: composer --version
@@ -156,6 +159,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           tools: composer:v2
           extensions: mysqli
+          coverage: none
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"


### PR DESCRIPTION
This avoid problems with Xdebug 3 (the version that now automatically
gets installed).