### PR TITLE
[BUGFIX] Downgrade the XLIFF files to version 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,7 @@ jobs:
       - name: "Download xliff schema"
         run: "wget https://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd"
       - name: "Run lint"
-        run: "xmllint --schema ./xliff-core-1.2-strict.xsd
-              --noout $(find Resources -name '*.xlf')"
+        run: "xmllint --schema ./xliff-core-1.2-strict.xsd --noout $(find Resources -name '*.xlf')"
   unit-tests:
     name: "Unit tests"
     runs-on: ubuntu-20.04

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.0">
 	<file source-language="en" target-language="de" datatype="plaintext" original="messages">
 		<header/>
 		<body>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.0">
 	<file source-language="en" target-language="de" datatype="plaintext" original="messages">
 		<header/>
 		<body>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.0">
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.0">
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>


### PR DESCRIPTION
This now matches what the TYPO3 Core uses.

We still use the XLIFF 1.2 schema for validation as version 1.2
is the first fully ratified version.

Closes #198