### PR TITLE
[TASK] Migrate TypoScript linting to a GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
       - name: "Run TypoScript lint"
-        uses: typo3-continous-integration/typo3-ci-typoscript-lint@v1
+        uses: TYPO3-Continuous-Integration/TYPO3-CI-Typoscript-Lint@v1
     strategy:
       fail-fast: false
   code-quality:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ jobs:
           - 7.2
           - 7.3
           - 7.4
+  typoscript-lint:
+    name: "TypoScript linter"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Run TypoScript lint"
+        uses: typo3-continous-integration/typo3-ci-typoscript-lint@v1
+    strategy:
+      fail-fast: false
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-20.04
@@ -57,7 +67,6 @@ jobs:
       fail-fast: false
       matrix:
         command:
-          - "ts:lint"
           - "yaml:lint"
           - "json:lint"
           - "php:sniff"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
         uses: actions/checkout@v2
       - name: "Run TypoScript lint"
         uses: TYPO3-Continuous-Integration/TYPO3-CI-Typoscript-Lint@v1
-    strategy:
-      fail-fast: false
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-20.04


### PR DESCRIPTION
I prepared github action for typoscript linting, migrate tea extension to use it as example
https://github.com/TYPO3-Continuous-Integration/TYPO3-CI-Typoscript-Lint