### PR TITLE
[TASK] Re-upgrade the XLIFF files to version 1.2

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.0">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
 	<file source-language="en" target-language="de" datatype="plaintext" original="messages">
 		<header/>
 		<body>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.0">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
 	<file source-language="en" target-language="de" datatype="plaintext" original="messages">
 		<header/>
 		<body>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.0">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.0">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>


### PR DESCRIPTION
Now that the Core uses XLIFF version 1.2, this extension
should do so (again), too.

This reverts commit e51dad6aeaca1859b9f8198a179f2134f18fcdef.