### PR TITLE
[TASK] Remove php occurencies in lint scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
 		"ci:dynamic": [
 			"@ci:tests"
 		],
-		"ci:json:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.json' | xargs @php .Build/vendor/bin/jsonlint -q",
+		"ci:json:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.json' | xargs php .Build/vendor/bin/jsonlint -q",
 		"ci:php": [
 			"@ci:php:copypaste",
 			"@ci:php:cs-fixer",
@@ -111,7 +111,7 @@
 		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml {}';",
 		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit",
 		"ci:ts:lint": "@php ./tools/typo3-typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
-		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.yml' | xargs @php ./tools/yaml-lint",
+		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.yml' | xargs php ./tools/yaml-lint",
 		"fix:php": [
 			"@fix:php:cs",
 			"@fix:php:sniff"

--- a/composer.json
+++ b/composer.json
@@ -76,11 +76,11 @@
 		"ci": [
 			"@ci:static"
 		],
-		"ci:composer:normalize": "./tools/composer-normalize --dry-run",
+		"ci:composer:normalize": "@php ./tools/composer-normalize --dry-run",
 		"ci:dynamic": [
 			"@ci:tests"
 		],
-		"ci:json:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.json' | xargs .Build/vendor/bin/jsonlint -q",
+		"ci:json:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.json' | xargs @php .Build/vendor/bin/jsonlint -q",
 		"ci:php": [
 			"@ci:php:copypaste",
 			"@ci:php:cs-fixer",
@@ -88,11 +88,11 @@
 			"@ci:php:sniff",
 			"@ci:php:stan"
 		],
-		"ci:php:copypaste": "./tools/phpcpd Classes Configuration Tests",
-		"ci:php:cs-fixer": "./tools/php-cs-fixer fix --config .php_cs.php -v --dry-run --using-cache false --diff --diff-format=udiff",
-		"ci:php:lint": "find *.php Classes Configuration Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
-		"ci:php:sniff": "./tools/phpcs Classes Configuration Tests",
-		"ci:php:stan": "./tools/phpstan analyse Classes",
+		"ci:php:copypaste": "@php ./tools/phpcpd Classes Configuration Tests",
+		"ci:php:cs-fixer": "@php ./tools/php-cs-fixer fix --config .php_cs.php -v --dry-run --using-cache false --diff --diff-format=udiff",
+		"ci:php:lint": "find *.php Classes Configuration Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 @php -l",
+		"ci:php:sniff": "@php ./tools/phpcs Classes Configuration Tests",
+		"ci:php:stan": "@php ./tools/phpstan analyse Classes",
 		"ci:static": [
 			"@ci:composer:normalize",
 			"@ci:json:lint",
@@ -110,14 +110,14 @@
 		],
 		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml {}';",
 		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit",
-		"ci:ts:lint": "./tools/typo3-typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
-		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.yml' | xargs ./tools/yaml-lint",
+		"ci:ts:lint": "@php ./tools/typo3-typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
+		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.yml' | xargs @php ./tools/yaml-lint",
 		"fix:php": [
 			"@fix:php:cs",
 			"@fix:php:sniff"
 		],
-		"fix:php:cs": "./tools/php-cs-fixer fix --config .php_cs.php",
-		"fix:php:sniff": ".Build/vendor/bin/phpcs Classes Configuration Tests",
+		"fix:php:cs": "@php ./tools/php-cs-fixer fix --config .php_cs.php",
+		"fix:php:sniff": "@php .Build/vendor/bin/phpcs Classes Configuration Tests",
 		"link-extension": [
 			"@php -r 'is_dir($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/\") || mkdir($extFolder, 0777, true);'",
 			"@php -r 'file_exists($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/tea\") || symlink(__DIR__,$extFolder);'"

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
 		"ci": [
 			"@ci:static"
 		],
-		"ci:composer:normalize": "php ./tools/composer-normalize --dry-run",
+		"ci:composer:normalize": "./tools/composer-normalize --dry-run",
 		"ci:dynamic": [
 			"@ci:tests"
 		],
@@ -88,11 +88,11 @@
 			"@ci:php:sniff",
 			"@ci:php:stan"
 		],
-		"ci:php:copypaste": "php ./tools/phpcpd Classes Configuration Tests",
-		"ci:php:cs-fixer": "php ./tools/php-cs-fixer fix --config .php_cs.php -v --dry-run --using-cache false --diff --diff-format=udiff",
+		"ci:php:copypaste": "./tools/phpcpd Classes Configuration Tests",
+		"ci:php:cs-fixer": "./tools/php-cs-fixer fix --config .php_cs.php -v --dry-run --using-cache false --diff --diff-format=udiff",
 		"ci:php:lint": "find *.php Classes Configuration Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
-		"ci:php:sniff": "php ./tools/phpcs Classes Configuration Tests",
-		"ci:php:stan": "php ./tools/phpstan analyse Classes",
+		"ci:php:sniff": "./tools/phpcs Classes Configuration Tests",
+		"ci:php:stan": "./tools/phpstan analyse Classes",
 		"ci:static": [
 			"@ci:composer:normalize",
 			"@ci:json:lint",
@@ -110,8 +110,8 @@
 		],
 		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml {}';",
 		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit",
-		"ci:ts:lint": "php ./tools/typo3-typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
-		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.yml' | xargs php ./tools/yaml-lint",
+		"ci:ts:lint": "./tools/typo3-typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
+		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.yml' | xargs ./tools/yaml-lint",
 		"fix:php": [
 			"@fix:php:cs",
 			"@fix:php:sniff"

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
 		],
 		"ci:php:copypaste": "@php ./tools/phpcpd Classes Configuration Tests",
 		"ci:php:cs-fixer": "@php ./tools/php-cs-fixer fix --config .php_cs.php -v --dry-run --using-cache false --diff --diff-format=udiff",
-		"ci:php:lint": "find *.php Classes Configuration Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 @php -l",
+		"ci:php:lint": "find *.php Classes Configuration Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
 		"ci:php:sniff": "@php ./tools/phpcs Classes Configuration Tests",
 		"ci:php:stan": "@php ./tools/phpstan analyse Classes",
 		"ci:static": [


### PR DESCRIPTION
Is there any case in which using php-cli is required here? I can execute them locally without any problems. We are not setting php in php-cs-fixer fix anyway. Maybe we could get rid of those?