### PR TITLE
[TASK] Limit the line length for Markdown files via `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -47,3 +47,7 @@ indent_style = tab
 # .htaccess
 [.htaccess]
 indent_style = tab
+
+# Markdown files
+[*.md]
+max_line_length = 80


### PR DESCRIPTION
The indentation of 4 spaces for Markdown and XML files already is
set via the default configuration in the `.editorconfig`.

Fixes #244