### PR TITLE
[BUGFIX] Fix default template names for GitLab CI

### DIFF
--- a/.gitlab/pipeline/.gitlab-ci.yml
+++ b/.gitlab/pipeline/.gitlab-ci.yml
@@ -7,7 +7,7 @@ stages:
   - test
 
 include:
-  - template: License-Management.gitlab-ci.yml
+  - template: Security/License-Scanning.gitlab-ci.yml
   - template: Secret-Detection.gitlab-ci.yml
   - template: SAST.gitlab-ci.yml
 

--- a/.gitlab/pipeline/.gitlab-ci.yml
+++ b/.gitlab/pipeline/.gitlab-ci.yml
@@ -8,8 +8,8 @@ stages:
 
 include:
   - template: Security/License-Scanning.gitlab-ci.yml
-  - template: Secret-Detection.gitlab-ci.yml
-  - template: SAST.gitlab-ci.yml
+  - template: Security/Secret-Detection.gitlab-ci.yml
+  - template: Security/SAST.gitlab-ci.yml
 
 variables:
   MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
GitLab offers default jobs for LicenseManagement, SecretDetection and SAST which are used here. However since some versions the filename of these includes was adapted and harmonised. Running the current files creates no pipelines due to a YAML error, as these includes are not found.