### PR TITLE
[FEATURE] Composer command for rendering documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Composer commands and scripts.
 |`ci:tests:unit`         | run the unit tests            | [PHPUnit](https://github.com/sebastianbergmann/phpunit/)                        |
 |`ci:ts:lint`            | lint the TypoScript files     | [TypoScript Lint](https://github.com/martin-helmich/typo3-typoscript-lint)      |
 |`ci:yaml:lint`          | lint the YAML files           | [yaml-lint](https://github.com/j13k/yaml-lint)                                  |
+|`docs:generate`         | render documentation          | [dockrun_t3rd](https://github.com/t3docs/docker-render-documentation#readme)    |
 |`fix:php`               | run all fixes for PHP         | the tools listed for the individual checks                                      |
 |`fix:php:cs`            | fix the code style            | [PHP Coding Standards Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer)      |
 |`fix:php:sniff`         | fix the code style            | [PHP_CodeSniffer (PHPCS)](https://github.com/squizlabs/PHP_CodeSniffer)         |

--- a/composer.json
+++ b/composer.json
@@ -70,9 +70,6 @@
 	},
 	"prefer-stable": true,
 	"scripts": {
-		"docs:generate": [
-			"docker run --rm t3docs/render-documentation show-shell-commands > tempfile.sh; echo 'dockrun_t3rd makehtml' >> tempfile.sh; bash tempfile.sh; rm tempfile.sh"
-		],
 		"post-autoload-dump": [
 			"@link-extension"
 		],
@@ -115,6 +112,9 @@
 		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit",
 		"ci:ts:lint": "@php ./tools/typo3-typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.yml' | xargs php ./tools/yaml-lint",
+		"docs:generate": [
+			"docker run --rm t3docs/render-documentation show-shell-commands > tempfile.sh; echo 'dockrun_t3rd makehtml' >> tempfile.sh; bash tempfile.sh; rm tempfile.sh"
+		],
 		"fix:php": [
 			"@fix:php:cs",
 			"@fix:php:sniff"

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,9 @@
 	},
 	"prefer-stable": true,
 	"scripts": {
+		"docs:generate": [
+			"docker run --rm t3docs/render-documentation show-shell-commands > tempfile.sh; echo 'dockrun_t3rd makehtml' >> tempfile.sh; bash tempfile.sh; rm tempfile.sh"
+		],
 		"post-autoload-dump": [
 			"@link-extension"
 		],


### PR DESCRIPTION
Adds the command `docs:generate` to `composer.json`.

Tested on macOS 11.5.2 (M1) and Docker 20.10.7.