### PR TITLE
[TASK] Use the Composer scripts for the CI builds by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ---
-name: CI
+# This GitHub Actions workflow uses the same development tools that are also installed locally
+# via Composer or PHIVE and calls them using the Composer scripts.
+name: CI with Composer scripts
 on:
   push:
     branches:
@@ -29,68 +31,6 @@ jobs:
           - 7.2
           - 7.3
           - 7.4
-  typoscript-lint:
-    name: "TypoScript linter"
-    runs-on: ubuntu-20.04
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2
-      - name: "Run TypoScript lint"
-        uses: TYPO3-Continuous-Integration/TYPO3-CI-Typoscript-Lint@v1
-  php-codesniffer:
-    name: "PHP Codesniffer"
-    runs-on: ubuntu-20.04
-    needs: php-lint
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2
-      - name: "Run PHP Codesniffer"
-        uses: TYPO3-Continuous-Integration/TYPO3-CI-PHP-Codesniffer@v1
-  yaml-lint:
-    name: "YAML linter"
-    runs-on: ubuntu-20.04
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2
-      - name: "Run YAML lint"
-        uses: TYPO3-Continuous-Integration/TYPO3-CI-YAML-Lint@v1
-  json-lint:
-    name: "JSON linter"
-    runs-on: ubuntu-20.04
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2
-      - name: "Run JSON lint"
-        uses: TYPO3-Continuous-Integration/TYPO3-CI-JSON-Lint@v1
-  php-cs-fixer:
-    name: "PHP CS Fixer"
-    runs-on: ubuntu-20.04
-    needs: php-lint
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2
-      - name: "Run PHP CS Fixer"
-        uses: TYPO3-Continuous-Integration/TYPO3-CI-PHP-CS-Fixer@v1
-  phpstan-check:
-    name: "PHPStan check"
-    runs-on: ubuntu-20.04
-    needs: php-lint
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2
-      - name: "Run PHPStan"
-        uses: TYPO3-Continuous-Integration/TYPO3-CI-PHPStan@v1
-        with:
-          config_file: './phpstan.neon'
-  copypaste-detector:
-    name: "Copy'n'paste detector"
-    runs-on: ubuntu-20.04
-    needs: php-lint
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2
-      - name: "Run the Copy'n'paste Detector"
-        uses: TYPO3-Continuous-Integration/TYPO3-CI-Copy-Paste-Detector@v1
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-20.04
@@ -119,8 +59,15 @@ jobs:
       fail-fast: false
       matrix:
         command:
-          - "composer:normalize"
+          - "ts:lint"
+          - "yaml:lint"
+          - "json:lint"
           - "php:sniff"
+          - "php:copypaste"
+          - "php:stan"
+          - "composer:normalize"
+          - "json:lint"
+          - "php:cs-fixer"
         php-version:
           - 7.4
   code-quality-frontend:

--- a/.github/workflows/predefined.yml
+++ b/.github/workflows/predefined.yml
@@ -1,10 +1,12 @@
+# This workflow does not use the Composer actions for calling the tools.
+# Use this workflow if you do not intend to call the code quality checks locally,
+# but only in the CI builds.
+#
+# Note that, to keep things fast, pull requests and pushes do not trigger this workflow.
+# If you are going to use this workflow, please copy the corresponding trigger settings from the `ci.yml` workflow.
 ---
-name: CI Composer scripts
+name: CI with predefined GitHub actions
 on:
-  push:
-    branches:
-      - main
-  pull_request:
   schedule:
     - cron: '15 3 * * 1'
 jobs:
@@ -29,6 +31,68 @@ jobs:
           - 7.2
           - 7.3
           - 7.4
+  typoscript-lint:
+    name: "TypoScript linter"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Run TypoScript lint"
+        uses: TYPO3-Continuous-Integration/TYPO3-CI-Typoscript-Lint@v1
+  php-codesniffer:
+    name: "PHP Codesniffer"
+    runs-on: ubuntu-20.04
+    needs: php-lint
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Run PHP Codesniffer"
+        uses: TYPO3-Continuous-Integration/TYPO3-CI-PHP-Codesniffer@v1
+  yaml-lint:
+    name: "YAML linter"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Run YAML lint"
+        uses: TYPO3-Continuous-Integration/TYPO3-CI-YAML-Lint@v1
+  json-lint:
+    name: "JSON linter"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Run JSON lint"
+        uses: TYPO3-Continuous-Integration/TYPO3-CI-JSON-Lint@v1
+  php-cs-fixer:
+    name: "PHP CS Fixer"
+    runs-on: ubuntu-20.04
+    needs: php-lint
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Run PHP CS Fixer"
+        uses: TYPO3-Continuous-Integration/TYPO3-CI-PHP-CS-Fixer@v1
+  phpstan-check:
+    name: "PHPStan check"
+    runs-on: ubuntu-20.04
+    needs: php-lint
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Run PHPStan"
+        uses: TYPO3-Continuous-Integration/TYPO3-CI-PHPStan@v1
+        with:
+          config_file: './phpstan.neon'
+  copypaste-detector:
+    name: "Copy'n'paste detector"
+    runs-on: ubuntu-20.04
+    needs: php-lint
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Run the Copy'n'paste Detector"
+        uses: TYPO3-Continuous-Integration/TYPO3-CI-Copy-Paste-Detector@v1
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-20.04
@@ -57,15 +121,8 @@ jobs:
       fail-fast: false
       matrix:
         command:
-          - "ts:lint"
-          - "yaml:lint"
-          - "json:lint"
-          - "php:sniff"
-          - "php:copypaste"
-          - "php:stan"
           - "composer:normalize"
-          - "json:lint"
-          - "php:cs-fixer"
+          - "php:sniff"
         php-version:
           - 7.4
   code-quality-frontend:

--- a/README.md
+++ b/README.md
@@ -95,15 +95,16 @@ the code quality checks locally:
 This extension has two code-checking workflows for
 [GitHub Actions](https://github.com/TYPO3-Documentation/tea/actions):
 
-- [one that completely relies on predefined actions](.github/workflows/ci.yml):
-  This workflow does not need the development tools to be installed via PHIVE.
+- [one that uses the local tools](.github/workflows/ci.yml):
+  This is the workflow you most probably would want to use:
+  This workflow uses the development tools installed via Composer and PHIVE and
+  calls them using the provided Composer scripts. Use this workflow if you want
+  to run the code quality checks locally as well as in GitHub Actions.
+
+- [one that completely relies on predefined actions](.github/workflows/predefined.yml):
+  This workflow does not need the development tools to be installed locally.
   Use this workflow if you only want to run the code quality checks in GitHub
   Actions, but not locally.
-
-- [one that uses the PHIVE-installed tools](.github/workflows/ci-composer-scripts.yml):
-  This workflow uses the development tools installed via PHIVE and calls them
-  using the provided Composer scripts. Use this workflow if want to run the code
-  quality checks locally as well as in GitHub Actions.
 
 #### GitLab CI
 


### PR DESCRIPTION
Also stop running the other CI workflow on every push/PR
(as the results of both workflows provide the same results).

Fixes #275