### PR TITLE
[TASK] Move the Composer script descriptions to the `composer.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ before you can use the Composer scripts.
 ### Available Composer scripts
 
 You can run `composer` (or `ddev composer`) to display a list of all available
-Composer commands and scripts.
+Composer commands and scripts. (For all custom Composer scripts, are descriptions
+in the `composer.json` in the `script-description` section.)
 
 ## Running the unit and functional tests
 

--- a/README.md
+++ b/README.md
@@ -127,27 +127,6 @@ before you can use the Composer scripts.
 You can run `composer` (or `ddev composer`) to display a list of all available
 Composer commands and scripts.
 
-| Script name            | Action                        | Tool                                                                            |
-|------------------------|-------------------------------|---------------------------------------------------------------------------------|
-|`ci`                    | run code checks               | the tools listed for the individual checks                                      |
-|`ci:composer:normalize` | normalize `composer.json`     | [composer-normalize](https://github.com/ergebnis/composer-normalize)            |
-|`ci:json:lint`          | lint the JSON files           | [JSON Lint](https://github.com/Seldaek/jsonlint)                                |
-|`ci:php`                | run all static checks for PHP | the tools listed for the individual checks                                      |
-|`ci:php:copypaste`      | check for copy'n'pasted code  | [PHP Copy/Paste Detector (PHPCPD)](https://github.com/sebastianbergmann/phpcpd) |
-|`ci:php:cs-fixer`       | check the code style          | [PHP Coding Standards Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer)      |
-|`ci:php:lint`           | lint the PHP files            | `php -l`                                                                        |
-|`ci:php:sniff`          | check the code style          | [PHP_CodeSniffer (PHPCS)](https://github.com/squizlabs/PHP_CodeSniffer)         |
-|`ci:php:stan`           | check the types               | [PHPStan](https://github.com/phpstan/phpstan)                                   |
-|`ci:tests:functional`   | run the functional tests      | [PHPUnit](https://github.com/sebastianbergmann/phpunit/)                        |
-|`ci:tests:tests`        | run all PHPUnit tests         | [PHPUnit](https://github.com/sebastianbergmann/phpunit/)                        |
-|`ci:tests:unit`         | run the unit tests            | [PHPUnit](https://github.com/sebastianbergmann/phpunit/)                        |
-|`ci:ts:lint`            | lint the TypoScript files     | [TypoScript Lint](https://github.com/martin-helmich/typo3-typoscript-lint)      |
-|`ci:yaml:lint`          | lint the YAML files           | [yaml-lint](https://github.com/j13k/yaml-lint)                                  |
-|`docs:generate`         | render documentation          | [dockrun_t3rd](https://github.com/t3docs/docker-render-documentation#readme)    |
-|`fix:php`               | run all fixes for PHP         | the tools listed for the individual checks                                      |
-|`fix:php:cs`            | fix the code style            | [PHP Coding Standards Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer)      |
-|`fix:php:sniff`         | fix the code style            | [PHP_CodeSniffer (PHPCS)](https://github.com/squizlabs/PHP_CodeSniffer)         |
-
 ## Running the unit and functional tests
 
 ### On the command line

--- a/composer.json
+++ b/composer.json
@@ -145,6 +145,28 @@
 			"rm phpcs.xml"
 		]
 	},
+	"scripts-descriptions": {
+		"ci": "Runs all dynamic and static code checks.",
+		"ci:composer:normalize": "Checks the composer.json.",
+		"ci:dynamic": "Runs alle PHPUnit tests (unit and functional).",
+		"ci:json:lint": "Lints the JSON files.",
+		"ci:php": "Runs all static checks for the PHP files.",
+		"ci:php:copypaste": "Checks for copy'n'pasted PHP code.",
+		"ci:php:cs-fixer": "Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).",
+		"ci:php:lint": "Lints the PHP files for syntax errors.",
+		"ci:php:sniff": "Checks the code style with PHP_CodeSniffer (PHPCS).",
+		"ci:php:stan": "Checks the PHP types using PHPStan.",
+		"ci:static": "Runs all static code checks (syntax, style, types).",
+		"ci:tests": "Runs alle PHPUnit tests (unit and functional).",
+		"ci:tests:functional": "Runs the functional tests.",
+		"ci:tests:unit": "Runs the unit tests.",
+		"ci:ts:lint": "Lints the TypoScript files.",
+		"ci:yaml:lint": "Lints the YAML files.",
+		"docs:generate": "Renders the extension ReST documentation.",
+		"fix:php": "Runs all fixers for the PHP code.",
+		"fix:php:cs": "Fixes the code style with PHP-CS-Fixer.",
+		"fix:php:sniff": "Fixes the code style with PHP_CodeSniffer."
+	},
 	"support": {
 		"issues": "https://github.com/TYPO3-Documentation/tea/issues",
 		"source": "https://github.com/TYPO3-Documentation/tea"

--- a/composer.json
+++ b/composer.json
@@ -148,7 +148,7 @@
 	"scripts-descriptions": {
 		"ci": "Runs all dynamic and static code checks.",
 		"ci:composer:normalize": "Checks the composer.json.",
-		"ci:dynamic": "Runs alle PHPUnit tests (unit and functional).",
+		"ci:dynamic": "Runs all PHPUnit tests (unit and functional).",
 		"ci:json:lint": "Lints the JSON files.",
 		"ci:php": "Runs all static checks for the PHP files.",
 		"ci:php:copypaste": "Checks for copy'n'pasted PHP code.",
@@ -157,7 +157,7 @@
 		"ci:php:sniff": "Checks the code style with PHP_CodeSniffer (PHPCS).",
 		"ci:php:stan": "Checks the PHP types using PHPStan.",
 		"ci:static": "Runs all static code checks (syntax, style, types).",
-		"ci:tests": "Runs alle PHPUnit tests (unit and functional).",
+		"ci:tests": "Runs all PHPUnit tests (unit and functional).",
 		"ci:tests:functional": "Runs the functional tests.",
 		"ci:tests:unit": "Runs the unit tests.",
 		"ci:ts:lint": "Lints the TypoScript files.",


### PR DESCRIPTION
Composer has a built-in functionality for describing Composer scripts,
and we should use it for documentating our custom scripts.