### PR TITLE
[BUGFIX] Complete the `typo3/cms` section in the `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,9 @@
 			"dev-main": "2.0.x-dev"
 		},
 		"typo3/cms": {
+			"app-dir": ".Build",
 			"extension-key": "tea",
+			"ignore-as-root": false,
 			"web-dir": ".Build/public"
 		}
 	},


### PR DESCRIPTION
- make the app dir explicit
- allow the root project to be used as an extension
  (this fixes the test in TYPO3 >= 11.4)