### PR TITLE
[BUGFIX] Only publish to the TER if the tag is a valid version number

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     tags:
-      - "**"
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Only publish to the TER if the tag is a valid version number (#329)
 
 ## 1.0.0
 


### PR DESCRIPTION
Tags named like `test-tag` should not trigger a TER releasen, but only
valid version numbers in the format major.minor.bugfix.

Fixes #327