### PR TITLE
[TASK] Only install Composer packages once in a CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           TYPO3: "${{ matrix.typo3-version }}"
         name: "Install TYPO3 Core"
         run: |
-          composer require --no-progress typo3/minimal:"$TYPO3"
+          composer require --no-ansi --no-interaction --no-progress --no-install typo3/minimal:"$TYPO3"
           composer show
       - if: "matrix.composer-dependencies == 'lowest'"
         name: "Install lowest dependencies with composer"
@@ -175,7 +175,7 @@ jobs:
           TYPO3: "${{ matrix.typo3-version }}"
         name: "Install TYPO3 Core"
         run: |
-          composer require --no-progress typo3/minimal:"$TYPO3"
+          composer require --no-ansi --no-interaction --no-progress --no-install typo3/minimal:"$TYPO3"
           composer show
       - if: "matrix.composer-dependencies == 'lowest'"
         name: "Install lowest dependencies with composer"


### PR DESCRIPTION
If the CI build will do a composer update in the next step anyway,
there is no need to actually install any packages when requiring
the desired TYPO3 version.

Fixes #324