### PR TITLE
[BUGFIX] Require at least TYPO3 11.5.2 for 11LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Allow installations on TYPO3 11LTS
 
 ### Changed
+- Require at least TYPO3 11.5.2 for 11LTS (#335)
 - Upgrade to PHPUnit 8.5 (#328)
 
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
 	],
 	"require": {
 		"php": "~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0",
-		"typo3/cms-core": "^9.5 || ^10.4 || ^11.5",
-		"typo3/cms-extbase": "^9.5 || ^10.4 || ^11.5",
-		"typo3/cms-fluid": "^9.5 || ^10.4 || ^11.5",
-		"typo3/cms-frontend": "^9.5 || ^10.4 || ^11.5"
+		"typo3/cms-core": "^9.5 || ^10.4 || ^11.5.2",
+		"typo3/cms-extbase": "^9.5 || ^10.4 || ^11.5.2",
+		"typo3/cms-fluid": "^9.5 || ^10.4 || ^11.5.2",
+		"typo3/cms-frontend": "^9.5 || ^10.4 || ^11.5.2"
 	},
 	"replace": {
 		"typo3-ter/tea": "self.version"
@@ -50,7 +50,7 @@
 		"seld/jsonlint": "^1.8.3",
 		"squizlabs/php_codesniffer": "^3.6.1",
 		"symfony/yaml": "^4.4.29 || ^5.3.6 || ^6.0",
-		"typo3/cms-fluid-styled-content": "^9.5 || ^10.4 || ^11.5"
+		"typo3/cms-fluid-styled-content": "^9.5 || ^10.4 || ^11.5.2"
 	},
 	"config": {
 		"preferred-install": {


### PR DESCRIPTION
This fixes a missing Symfony polyfill for `str_starts_with` in
TYPO3 11.5.0 and 11.5.1, which fixes a crash in the unit tests with
TYPO3 11LTS and PHP 7.4 using the lowest possible Composer dependencies.