### PR TITLE
[TASK] allow newlines for ternary operator

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -122,7 +122,11 @@
     <rule ref="PEAR.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.WhiteSpace.CastSpacing"/>
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true" />
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.PropertyLabelSpacing"/>
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
 </ruleset>


### PR DESCRIPTION
The previous configuration disallowed newlines in ternary operator like:

```
$a = $condition1 && $condition2
    ? $foo_man_this_is_too_long_what_should_i_do
    : $bar;
```

This seems very arbitrary since breaking on other operators is in fact
allowed.

This change allows such longer statements to be broken apart over
several lines.

Fixes #337
