### PR TITLE
[BUGFIX] Pin Composer to version 2.1.x

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -18,7 +18,7 @@ hooks:
 omit_containers: [dba, ddev-ssh-agent]
 webimage_extra_packages: [parallel]
 use_dns_when_possible: true
-composer_version: ""
+composer_version: "2.1.14"
 web_environment:
 - typo3DatabaseName=typo3
 - typo3DatabaseHost=db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2
+          tools: composer:v2.1
       - name: "Run PHP lint"
         run: "composer ci:php:lint"
     strategy:
@@ -43,7 +43,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2
+          tools: composer:v2.1
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -109,7 +109,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2
+          tools: composer:v2.1
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -199,7 +199,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2
+          tools: composer:v2.1
           extensions: mysqli
           coverage: none
       - name: "Show Composer version"

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -18,7 +18,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           coverage: xdebug
           extensions: xdebug, mysqli
-          tools: composer:v2
+          tools: composer:v2.1
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"

--- a/.github/workflows/predefined.yml
+++ b/.github/workflows/predefined.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2
+          tools: composer:v2.1
       - name: "Run PHP lint"
         run: "composer ci:php:lint"
     strategy:
@@ -104,7 +104,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2
+          tools: composer:v2.1
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -163,7 +163,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2
+          tools: composer:v2.1
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -214,7 +214,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2
+          tools: composer:v2.1
           extensions: mysqli
           coverage: none
       - name: "Show Composer version"


### PR DESCRIPTION
Composer versions 2.2.0 and 2.2.1 have a bug that breaks PHPUnit.
Until version 2.2.2 is released with a fix, we need to keep to
Composer 2.1 to keep the tests from breaking.

See https://github.com/composer/composer/issues/10387 for details.