### PR TITLE
[BUGFIX] Explicitly allow the development Composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,10 +69,10 @@
 	},
 	"config": {
 		"allow-plugins": {
-			"ergebnis/composer-normalize": false,
-			"phpstan/extension-installer": false,
-			"typo3/class-alias-loader": false,
-			"typo3/cms-composer-installers": false
+			"ergebnis/composer-normalize": true,
+			"phpstan/extension-installer": true,
+			"typo3/class-alias-loader": true,
+			"typo3/cms-composer-installers": true
 		},
 		"preferred-install": {
 			"*": "dist"


### PR DESCRIPTION
This will allow Composer plugins like composer-normalize to run
in Composer >= 2.2 as well.