### PR TITLE
[TASK] Always run the CI build after a push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@
 name: CI with Composer scripts
 on:
   push:
-    branches:
-      - main
-  pull_request:
   schedule:
     - cron: '15 3 * * 1'
 jobs:


### PR DESCRIPTION
This will allow us to test things on the CI pipeline without
having to create a dummy/draft PR for this.

Hopefully, this will also allow builds for forks.