### PR TITLE
[BUGFIX] Fix CI builds for PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@
 name: CI with Composer scripts
 on:
   push:
+    branches:
+      - main
+  pull_request:
   schedule:
     - cron: '15 3 * * 1'
 jobs:


### PR DESCRIPTION
It has turned out that having builds only for pushes (but not
pull requests) is not enough for triggering builds for PRs
from forks.

So we will need to live with pushes to non-PR branches other
than main not triggering a build, and having to create a
dummy draft PR for testing the CI build.

This reverts commit d1f02afe7975c6f66221077aca077f71f84bcbdf.

Fixes #359