### PR TITLE
[TASK] Switch to the core testing framework

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -29,27 +29,6 @@ namespace PHPSTORM_META {
         )
     );
 
-    // Nimut testing framework
-    // The accesible mock will be of type `self` as well as `MockObject` and `AccessibleMockObjectInterface`.
-    override(
-        \Nimut\TestingFramework\TestCase\AbstractTestCase::getAccessibleMock(0),
-        map(
-            [
-                '' => '@|\\PHPUnit\\Framework\\MockObject\\MockObject'
-                    . '|\\Nimut\\TestingFramework\\MockObject\\AccessibleMockObjectInterface',
-            ]
-        )
-    );
-    override(
-        \Nimut\TestingFramework\TestCase\AbstractTestCase::getAccessibleMockForAbstractClass(0),
-        map(
-            [
-                '' => '@|\\PHPUnit\\Framework\\MockObject\\MockObject'
-                    . '|\\Nimut\TestingFramework\\MockObject\\AccessibleMockObjectInterface',
-            ]
-        )
-    );
-
     // Contexts
     // @see https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Feature-85389-ContextAPIForConsistentDataHandling.html
     expectedArguments(

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ settings so this configuration can serve as a template:
 
 - Directory: use the `Tests/Unit` directory in your project
 - (*) Use alternative configuration file
-- use `.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml`
+- use `.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml`
   in your project folder
 - add the following environment variables:
   - typo3DatabaseUsername
@@ -204,7 +204,7 @@ settings:
 - Directory: use the `Tests/Functional` directory in your project
 - (*) Use alternative configuration file
 - use
-  `.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml`
+  `.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml`
 
 ## Running the acceptance tests
 

--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -125,7 +125,7 @@ class TeaRepositoryTest extends FunctionalTestCase
         $connection = $this->getConnectionPool()
             ->getConnectionForTable('tx_tea_domain_model_product_tea');
         $databaseRow = $connection->select(['*'], 'tx_tea_domain_model_product_tea', ['uid' => $model->getUid()])
-            ->fetch(\PDO::FETCH_ASSOC);
+            ->fetchAssociative();
 
         self::assertSame($title, $databaseRow['title']);
     }

--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -125,7 +125,7 @@ class TeaRepositoryTest extends FunctionalTestCase
         $connection = $this->getConnectionPool()
             ->getConnectionForTable('tx_tea_domain_model_product_tea');
         $databaseRow = $connection->select(['*'], 'tx_tea_domain_model_product_tea', ['uid' => $model->getUid()])
-            ->fetchAssociative();
+            ->fetch(\PDO::FETCH_ASSOC);
 
         self::assertSame($title, $databaseRow['title']);
     }

--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace TTN\Tea\Tests\Functional\Domain\Repository\Product;
 
-use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TTN\Tea\Domain\Model\Product\Tea;
 use TTN\Tea\Domain\Repository\Product\TeaRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
  * @covers \TTN\Tea\Domain\Repository\Product\TeaRepository
@@ -18,7 +18,7 @@ use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 class TeaRepositoryTest extends FunctionalTestCase
 {
     /**
-     * @var string[]
+     * @var array<int, string>
      */
     protected $testExtensionsToLoad = ['typo3conf/ext/tea'];
 
@@ -122,11 +122,11 @@ class TeaRepositoryTest extends FunctionalTestCase
         $this->subject->add($model);
         $this->persistenceManager->persistAll();
 
-        $databaseRow = $this->getDatabaseConnection()->selectSingleRow(
-            '*',
-            'tx_tea_domain_model_product_tea',
-            'uid = ' . $model->getUid()
-        );
+        $connection = $this->getConnectionPool()
+            ->getConnectionForTable('tx_tea_domain_model_product_tea');
+        $databaseRow = $connection->select(['*'], 'tx_tea_domain_model_product_tea', ['uid' => $model->getUid()])
+            ->fetchAssociative();
+
         self::assertSame($title, $databaseRow['title']);
     }
 }

--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -125,7 +125,7 @@ class TeaRepositoryTest extends FunctionalTestCase
         $connection = $this->getConnectionPool()
             ->getConnectionForTable('tx_tea_domain_model_product_tea');
         $databaseRow = $connection->select(['*'], 'tx_tea_domain_model_product_tea', ['uid' => $model->getUid()])
-            ->fetchAllAssociative();
+            ->fetchOne();
 
         self::assertSame($title, $databaseRow['title']);
     }

--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -125,7 +125,7 @@ class TeaRepositoryTest extends FunctionalTestCase
         $connection = $this->getConnectionPool()
             ->getConnectionForTable('tx_tea_domain_model_product_tea');
         $databaseRow = $connection->select(['*'], 'tx_tea_domain_model_product_tea', ['uid' => $model->getUid()])
-            ->fetchAssociative();
+            ->fetchAllAssociative();
 
         self::assertSame($title, $databaseRow['title']);
     }

--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -125,7 +125,7 @@ class TeaRepositoryTest extends FunctionalTestCase
         $connection = $this->getConnectionPool()
             ->getConnectionForTable('tx_tea_domain_model_product_tea');
         $databaseRow = $connection->select(['*'], 'tx_tea_domain_model_product_tea', ['uid' => $model->getUid()])
-            ->fetchOne();
+            ->fetchAssociative();
 
         self::assertSame($title, $databaseRow['title']);
     }

--- a/Tests/Unit/Controller/TeaControllerTest.php
+++ b/Tests/Unit/Controller/TeaControllerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TTN\Tea\Tests\Unit\Controller;
 
-use Nimut\TestingFramework\TestCase\UnitTestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophecy\ProphecySubjectInterface;
 use TTN\Tea\Controller\TeaController;
@@ -13,6 +12,7 @@ use TTN\Tea\Domain\Repository\Product\TeaRepository;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Fluid\View\TemplateView;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
  * @covers \TTN\Tea\Controller\TeaController
@@ -36,11 +36,14 @@ class TeaControllerTest extends UnitTestCase
 
     protected function setUp(): void
     {
-        $this->subject = new TeaController();
+        parent::setUp();
+
+        // We need to create an accessible mock in order to be able to set the protected `view`.
+        $this->subject = $this->getAccessibleMock(TeaController::class, ['redirect', 'forward']);
 
         $this->viewProphecy = $this->prophesize(TemplateView::class);
         $view = $this->viewProphecy->reveal();
-        $this->inject($this->subject, 'view', $view);
+        $this->subject->_set('view', $view);
 
         $this->teaRepositoryProphecy = $this->prophesize(TeaRepository::class);
         /** @var TeaRepository&ProphecySubjectInterface $teaRepository */

--- a/Tests/Unit/Domain/Model/Product/TeaTest.php
+++ b/Tests/Unit/Domain/Model/Product/TeaTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace TTN\Tea\Tests\Unit\Domain\Model\Product;
 
-use Nimut\TestingFramework\TestCase\UnitTestCase;
 use TTN\Tea\Domain\Model\Product\Tea;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
  * @covers \TTN\Tea\Domain\Model\Product\Tea
@@ -21,6 +21,8 @@ class TeaTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new Tea();
     }
 

--- a/Tests/Unit/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/Product/TeaRepositoryTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace TTN\Tea\Tests\Unit\Domain\Repository\Product;
 
-use Nimut\TestingFramework\TestCase\UnitTestCase;
 use TTN\Tea\Domain\Repository\Product\TeaRepository;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
  * @covers \TTN\Tea\Domain\Repository\Product\TeaRepository
@@ -26,6 +26,8 @@ class TeaRepositoryTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->objectManager = $this->prophesize(ObjectManagerInterface::class)->reveal();
         $this->subject = new TeaRepository($this->objectManager);
     }

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
 		"symfony/yaml": "^4.4.29 || ^5.3.6 || ^6.0",
 		"typo3/cms-fluid-styled-content": "^10.4 || ^11.5.2",
 		"typo3/coding-standards": "^0.5.0",
-		"typo3/testing-framework": "^6.15.2"
+		"typo3/testing-framework": "^6.15.3"
 	},
 	"replace": {
 		"typo3-ter/tea": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
 	},
 	"require-dev": {
 		"codeception/codeception": "^4.1.27",
+		"doctrine/dbal": "^2.13.5",
 		"ergebnis/composer-normalize": "^2.18.0",
 		"friendsofphp/php-cs-fixer": "^3.4.0",
 		"helmich/typo3-typoscript-lint": "^2.5.2",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
 		"friendsofphp/php-cs-fixer": "^3.4.0",
 		"helmich/typo3-typoscript-lint": "^2.5.2",
 		"jangregor/phpstan-prophecy": "^1.0.0",
-		"nimut/testing-framework": "^6.0.0",
 		"phpstan/extension-installer": "^1.1.0",
 		"phpstan/phpstan": "^1.2.0",
 		"phpstan/phpstan-phpunit": "^1.0.0",
@@ -47,7 +46,8 @@
 		"squizlabs/php_codesniffer": "^3.6.2",
 		"symfony/yaml": "^4.4.29 || ^5.3.6 || ^6.0",
 		"typo3/cms-fluid-styled-content": "^10.4 || ^11.5.2",
-		"typo3/coding-standards": "^0.5.0"
+		"typo3/coding-standards": "^0.5.0",
+		"typo3/testing-framework": "^6.15.2"
 	},
 	"replace": {
 		"typo3-ter/tea": "self.version"
@@ -137,8 +137,8 @@
 			"@ci:tests:unit",
 			"@ci:tests:functional"
 		],
-		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml {}';",
-		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit",
+		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml {}';",
+		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml Tests/Unit",
 		"ci:ts:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.yml' | xargs -r php ./.Build/vendor/bin/yaml-lint",
 		"docs:generate": [


### PR DESCRIPTION
The TYPO3 core testing framework has more person-power for maintenance
behind it compared to the nimut testing framework. So we should use that.