### PR TITLE
[TASK] Use Composer 2.2 in the CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.1
+          tools: composer:v2.2
       - name: "Run PHP lint"
         run: "composer ci:php:lint"
     strategy:
@@ -40,7 +40,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.1
+          tools: composer:v2.2
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -106,7 +106,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.1
+          tools: composer:v2.2
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -196,7 +196,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2.1
+          tools: composer:v2.2
           extensions: mysqli
           coverage: none
       - name: "Show Composer version"

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -18,7 +18,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           coverage: xdebug
           extensions: xdebug, mysqli
-          tools: composer:v2.1
+          tools: composer:v2.2
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"

--- a/.github/workflows/predefined.yml
+++ b/.github/workflows/predefined.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.1
+          tools: composer:v2.2
       - name: "Run PHP lint"
         run: "composer ci:php:lint"
     strategy:
@@ -104,7 +104,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.1
+          tools: composer:v2.2
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -163,7 +163,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.1
+          tools: composer:v2.2
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -214,7 +214,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2.1
+          tools: composer:v2.2
           extensions: mysqli
           coverage: none
       - name: "Show Composer version"


### PR DESCRIPTION
With the releases of Composer 2.2.2 and 2.2.3 (and PHPUnit 9.5.11),
running the tests with Composer 2 in the pipeline should be safe afain.