### PR TITLE
[TASK] Drop support for TYPO3 9LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,24 +140,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: ^9.5
-            php-version: 7.2
-            composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.2
-            composer-dependencies: lowest
-          - typo3-version: ^9.5
-            php-version: 7.3
-            composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.3
-            composer-dependencies: lowest
-          - typo3-version: ^9.5
-            php-version: 7.4
-            composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.4
-            composer-dependencies: lowest
           - typo3-version: ^10.4
             php-version: 7.2
             composer-dependencies: highest
@@ -246,5 +228,4 @@ jobs:
           - 7.3
           - 7.4
         typo3-version:
-          - ^9.5
           - ^10.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop support for TYPO3 9LTS (#363)
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
 	},
 	"require": {
 		"php": "~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0",
-		"typo3/cms-core": "^9.5 || ^10.4 || ^11.5.2",
-		"typo3/cms-extbase": "^9.5 || ^10.4 || ^11.5.2",
-		"typo3/cms-fluid": "^9.5 || ^10.4 || ^11.5.2",
-		"typo3/cms-frontend": "^9.5 || ^10.4 || ^11.5.2"
+		"typo3/cms-core": "^10.4 || ^11.5.2",
+		"typo3/cms-extbase": "^10.4 || ^11.5.2",
+		"typo3/cms-fluid": "^10.4 || ^11.5.2",
+		"typo3/cms-frontend": "^10.4 || ^11.5.2"
 	},
 	"require-dev": {
 		"codeception/codeception": "^4.1.27",
@@ -46,7 +46,7 @@
 		"seld/jsonlint": "^1.8.3",
 		"squizlabs/php_codesniffer": "^3.6.2",
 		"symfony/yaml": "^4.4.29 || ^5.3.6 || ^6.0",
-		"typo3/cms-fluid-styled-content": "^9.5 || ^10.4 || ^11.5.2",
+		"typo3/cms-fluid-styled-content": "^10.4 || ^11.5.2",
 		"typo3/coding-standards": "^0.5.0"
 	},
 	"replace": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,7 +8,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'php' => '7.2.0-7.4.99',
-            'typo3' => '9.5.0-11.5.99',
+            'typo3' => '10.4.0-11.5.99',
         ],
     ],
     'state' => 'stable',


### PR DESCRIPTION
Now that we have added support for TYPO3 11LTS, we have been supporting
3 different TYPO3 LTS versions in the same branch. This has turned out
to be too much of a hassle when running the test. So now is the time
to drop support for 9LTS.