### PR TITLE
[BUGFIX] Avoid php-cs-fixer 3.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
 	},
 	"conflict": {
 		"doctrine/dbal": "2.13.1",
+		"friendsofphp/php-cs-fixer": "3.5.0",
 		"typo3/class-alias-loader": "< 1.1.0"
 	},
 	"prefer-stable": true,


### PR DESCRIPTION
Version 3.5.0 has a bug concerning intersection types that breaks our
build.

Fixes #368