### PR TITLE
[BUGFIX] install and use wait-for-it for functional tests

### DIFF
--- a/.gitlab/build/docker_install.sh
+++ b/.gitlab/build/docker_install.sh
@@ -5,7 +5,7 @@
 set -xe
 
 apt-get update -yqq
-apt-get install git libzip-dev unzip parallel libxml2-utils wget -yqq
+apt-get install git libzip-dev unzip parallel libxml2-utils wget wait-for-it -yqq
 
 php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin/ --filename=composer
 chmod +x /usr/local/bin/composer

--- a/.gitlab/pipeline/jobs/func-php7.2-v10.yml
+++ b/.gitlab/pipeline/jobs/func-php7.2-v10.yml
@@ -9,4 +9,4 @@ func-php7.2-v10:
     - php-lint-php7.2
   script:
     - composer require --no-progress typo3/minimal:"^10.4"
-    - composer ci:tests:functional
+    - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php7.2-v9.yml
+++ b/.gitlab/pipeline/jobs/func-php7.2-v9.yml
@@ -10,4 +10,4 @@ func-php7.2-v9:
     - php-lint-php7.2
   script:
     - composer require --no-progress typo3/minimal:"^9.5"
-    - composer ci:tests:functional
+    - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php7.3-v10.yml
+++ b/.gitlab/pipeline/jobs/func-php7.3-v10.yml
@@ -9,4 +9,4 @@ func-php7.3-v10:
     - php-lint-php7.3
   script:
     - composer require --no-progress typo3/minimal:"^10.4"
-    - composer ci:tests:functional
+    - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php7.3-v9.yml
+++ b/.gitlab/pipeline/jobs/func-php7.3-v9.yml
@@ -10,4 +10,4 @@ func-php7.3-v9:
     - php-lint-php7.3
   script:
     - composer require --no-progress typo3/minimal:"^9.5"
-    - composer ci:tests:functional
+    - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php7.4-v10.yml
+++ b/.gitlab/pipeline/jobs/func-php7.4-v10.yml
@@ -9,4 +9,4 @@ func-php7.4-v10:
     - php-lint-php7.4
   script:
     - composer require --no-progress typo3/minimal:"^10.4"
-    - composer ci:tests:functional
+    - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php7.4-v9.yml
+++ b/.gitlab/pipeline/jobs/func-php7.4-v9.yml
@@ -10,4 +10,4 @@ func-php7.4-v9:
     - php-lint-php7.4
   script:
     - composer require --no-progress typo3/minimal:"^9.5"
-    - composer ci:tests:functional
+    - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional


### PR DESCRIPTION
It might happen, when starting the fuctional test that the database service container is not ready yet. 

This patch provides an extra timeout to wait for the service to make sure the test does not fail because of missing database.