### PR TITLE
[BUGFIX] Fix some `.gitignore` entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /*.idea
 /.Build/*
-/.php_cs.cache
+/.php-cs-fixer.cache
+/.phpunit.result.cache
 /Documentation-GENERATED-temp/
 /Resources/Private/node_modules/
 /Resources/Private/package-lock.json


### PR DESCRIPTION
- `.php_cs.cache` file was renamed to `.php-cs-fixer.cache`
- `.phpunit.result.cache` missing in `.gitignore`