### PR TITLE
[BUGFIX] Stop using the vendor name for plugin registration

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -4,8 +4,8 @@ defined('TYPO3_MODE') || die();
 
 // This makes the plugin selectable in the BE.
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-    // extension name, exactly matching the PHP namespaces (vendor and product)
-    'TTN.Tea',
+    // extension name, matching the PHP namespaces (but without the vendor)
+    'Tea',
     // arbitrary, but unique plugin name (not visible in the BE)
     'Tea',
     // plugin title, as visible in the drop-down in the BE

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,8 +5,8 @@ defined('TYPO3_MODE') or die('Access denied.');
 (static function () {
     // This makes the plugin available for front-end rendering.
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        // extension name, exactly matching the PHP namespaces (vendor and product)
-        'TTN.Tea',
+        // extension name, matching the PHP namespaces (but without the vendor)
+        'Tea',
         // arbitrary, but unique plugin name (not visible in the BE)
         'Tea',
         // all actions


### PR DESCRIPTION
This has been deprecated in TYPO3 10.0:

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Deprecation-87550-UseControllerClassesWhenRegisteringPluginsmodules.html

Fixes #383