### PR TITLE
[BUGFIX] Remove `showRecordFieldList` from the TCA

### DIFF
--- a/Configuration/TCA/tx_tea_domain_model_product_tea.php
+++ b/Configuration/TCA/tx_tea_domain_model_product_tea.php
@@ -12,9 +12,6 @@ $tca = [
         'iconfile' => 'EXT:tea/Resources/Public/Icons/Record.svg',
         'searchFields' => 'title, description',
     ],
-    'interface' => [
-        'showRecordFieldList' => 'title, description, image',
-    ],
     'types' => [
         '1' => ['showitem' => 'title, description, image'],
     ],


### PR DESCRIPTION
This entry was deprecated in TYPO3 10.3:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.3/Feature-88901-RenderAllFieldsInElementInformationController.html

Fixes #384