### PR TITLE
[TASK] Use an explicit CI matrix for the functional tests as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,12 +227,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        composer-dependencies:
-          - highest
-          - lowest
-        php-version:
-          - 7.2
-          - 7.3
-          - 7.4
-        typo3-version:
-          - ^10.4
+        include:
+          - typo3-version: ^10.4
+            php-version: 7.2
+            composer-dependencies: highest
+          - typo3-version: ^10.4
+            php-version: 7.2
+            composer-dependencies: lowest
+          - typo3-version: ^10.4
+            php-version: 7.3
+            composer-dependencies: highest
+          - typo3-version: ^10.4
+            php-version: 7.3
+            composer-dependencies: lowest
+          - typo3-version: ^10.4
+            php-version: 7.4
+            composer-dependencies: highest
+          - typo3-version: ^10.4
+            php-version: 7.4
+            composer-dependencies: lowest

--- a/.github/workflows/predefined.yml
+++ b/.github/workflows/predefined.yml
@@ -251,13 +251,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        composer-dependencies:
-          - highest
-          - lowest
-        php-version:
-          - 7.2
-          - 7.3
-          - 7.4
-        typo3-version:
-          - ^9.5
-          - ^10.4
+        include:
+          - typo3-version: ^10.4
+            php-version: 7.2
+            composer-dependencies: highest
+          - typo3-version: ^10.4
+            php-version: 7.2
+            composer-dependencies: lowest
+          - typo3-version: ^10.4
+            php-version: 7.3
+            composer-dependencies: highest
+          - typo3-version: ^10.4
+            php-version: 7.3
+            composer-dependencies: lowest
+          - typo3-version: ^10.4
+            php-version: 7.4
+            composer-dependencies: highest
+          - typo3-version: ^10.4
+            php-version: 7.4
+            composer-dependencies: lowest


### PR DESCRIPTION
This will allow use to have exceptions from the cross product of
the parameters more easily (e.g., using PHP 8 only for TYPO3 11LTS
onward).