### PR TITLE
[BUGFIX] Remove duplicate entry from the code quality CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,15 +61,14 @@ jobs:
       fail-fast: false
       matrix:
         command:
-          - "ts:lint"
-          - "yaml:lint"
-          - "json:lint"
-          - "php:sniff"
-          - "php:copypaste"
-          - "php:stan"
           - "composer:normalize"
           - "json:lint"
+          - "php:copypaste"
           - "php:cs-fixer"
+          - "php:sniff"
+          - "ts:lint"
+          - "php:stan"
+          - "yaml:lint"
         php-version:
           - 7.4
   code-quality-frontend:


### PR DESCRIPTION
`json:lint` was there twice.

Also sort the code quality jobs the same way the corresponding tasks
are sorted in the `composer.json`.