### PR TITLE
[BUGFIX] Fix the trigger syntax in the CI builds

### DIFF
--- a/.github/workflows/predefined.yml
+++ b/.github/workflows/predefined.yml
@@ -7,6 +7,7 @@
 ---
 name: CI with predefined GitHub actions
 on:
+  workflow_dispatch:
 jobs:
   php-lint:
     name: "PHP linter"


### PR DESCRIPTION
The CI workflow with predefined GitHub actions had an empty `on:`
element, which is invalid. Use the correct event for manually
triggered workflow runs instead.