### PR TITLE
[BUGFIX] Use the correct Composer cache directory for CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,9 @@ jobs:
           coverage: none
           tools: composer:v2.2
       - name: "Show Composer version"
-        run: composer --version
+        run: |
+          composer --version
+          composer config --list
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
The cache directory has changed with Composer 2, and we need to
adapt our CI cache configuration accordingly.