### PR TITLE
[BUGFIX] Configure DI and avoid using `ObjectManager` in TYPO3 11LTS

### DIFF
--- a/Classes/Domain/Repository/Traits/StoragePageAgnosticTrait.php
+++ b/Classes/Domain/Repository/Traits/StoragePageAgnosticTrait.php
@@ -14,10 +14,20 @@ use TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface;
  */
 trait StoragePageAgnosticTrait
 {
+    /**
+     * @var QuerySettingsInterface
+     */
+    private $querySettings;
+
+    public function injectQuerySettings(QuerySettingsInterface $querySettings): void
+    {
+        $this->querySettings = $querySettings;
+    }
+
     public function initializeObject(): void
     {
-        /** @var QuerySettingsInterface $querySettings */
-        $querySettings = $this->objectManager->get(QuerySettingsInterface::class);
+        $querySettings = clone $this->querySettings;
+
         $querySettings->setRespectStoragePage(false);
         $this->setDefaultQuerySettings($querySettings);
     }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,9 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  TTN\Tea\:
+    resource: '../Classes/*'
+    exclude: '../Classes/Domain/Model/*'

--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -6,6 +6,7 @@ namespace TTN\Tea\Tests\Functional\Domain\Repository\Product;
 
 use TTN\Tea\Domain\Model\Product\Tea;
 use TTN\Tea\Domain\Repository\Product\TeaRepository;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -38,9 +39,15 @@ class TeaRepositoryTest extends FunctionalTestCase
 
         $this->persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
 
-        /** @var ObjectManager $objectManager */
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->subject = $objectManager->get(TeaRepository::class);
+        /** @var Typo3Version $versionInformation */
+        $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
+        if ($versionInformation->getMajorVersion() >= 11) {
+            $this->subject = $this->getContainer()->get(TeaRepository::class);
+        } else {
+            /** @var ObjectManager $objectManager */
+            $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+            $this->subject = $objectManager->get(TeaRepository::class);
+        }
     }
 
     /**


### PR DESCRIPTION
`ObjectManager` is deprecated in V11.

Fixes #387