### PR TITLE
[BUGFIX] Remove folders `Config` and `Tests` from phpcpd call

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,7 @@
 			"@ci:php:sniff",
 			"@ci:php:stan"
 		],
-		"ci:php:copypaste": "@php ./tools/phpcpd Classes Configuration Tests",
+		"ci:php:copypaste": "@php ./tools/phpcpd Classes",
 		"ci:php:cs-fixer": "php-cs-fixer fix --config .php-cs-fixer.php -v --dry-run --using-cache no --diff",
 		"ci:php:lint": "find *.php Classes Configuration Tests -name '*.php' -print0 | xargs -r -0 -n 1 -P 4 php -l",
 		"ci:php:sniff": "phpcs Classes Configuration Tests",


### PR DESCRIPTION
phpcpd gives a lot of false positives (in the sense that the code can't be changed or it does not make sense to change it) in TCA definitions and tests.

Resolves #410