### PR TITLE
[TASK] Bump the code coverage generation to TYPO3 11LTS and PHP 8.1

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -62,6 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 7.4
+          - 8.1
         typo3-version:
-          - ^10.4
+          - ^11.5


### PR DESCRIPTION
We should use the latest TYPO3 and PHP versions for code coverage
generation.