### PR TITLE
[DOCS] Reference manual's start page with :doc:`<manual>:Index`

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -45,7 +45,7 @@ project_repository = https://github.com/TYPO3-Documentation/tea
 # You must uncomment all manuals you use in your cross-references
 #
 # Example usage:
-#   :ref:`t3contribute:start` will link to start page of Contribution Guide
+#   :doc:`t3contribute:Index` will link to start page of Contribution Guide
 # .................................................................................
 # t3coreapi = https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/
 # t3editors = https://docs.typo3.org/m/typo3/tutorial-editors/master/en-us/


### PR DESCRIPTION
Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/185