### PR TITLE
[BUGFIX] Use `executeQuery()` in functional test example

### DIFF
--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -131,7 +131,10 @@ class TeaRepositoryTest extends FunctionalTestCase
 
         $connection = $this->getConnectionPool()
             ->getConnectionForTable('tx_tea_domain_model_product_tea');
-        $databaseRow = $connection->select(['*'], 'tx_tea_domain_model_product_tea', ['uid' => $model->getUid()])
+        $databaseRow = $connection
+            ->executeQuery(
+                'SELECT * FROM tx_tea_domain_model_product_tea WHERE uid = ' . $model->getUid()
+            )
             ->fetchAssociative();
 
         self::assertSame($title, $databaseRow['title']);


### PR DESCRIPTION
This avoids potential false results in the tests because it doesn't add additional restrictions for starttime, endtime, deleted, and hidden.

Fixes #421