### PR TITLE
[TASK] Sync the GitHub Actions job definitions

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -16,22 +16,32 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          coverage: xdebug
-          extensions: xdebug, mysqli
           tools: composer:v2.3
+          extensions: xdebug, mysqli
+          coverage: xdebug
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v3
         with:
-          key: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-composer-${{ hashFiles('**/composer.json') }}"
+          key: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-${{ hashFiles('**/composer.json') }}"
           path: ~/.cache/composer
-          restore-keys: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-composer-\n"
+          restore-keys: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-\n"
       - name: "Install TYPO3 Core"
         env:
           TYPO3: "${{ matrix.typo3-version }}"
         run: |
-          composer require --no-progress typo3/minimal:"$TYPO3"
+          composer require --no-ansi --no-interaction --no-progress --no-install typo3/minimal:"$TYPO3"
+          composer show
+      - name: "Install lowest dependencies with composer"
+        if: "matrix.composer-dependencies == 'lowest'"
+        run: |
+          composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
+          composer show
+      - name: "Install highest dependencies with composer"
+        if: "matrix.composer-dependencies == 'highest'"
+        run: |
+          composer update --no-ansi --no-interaction --no-progress --with-dependencies
           composer show
       - name: "Start MySQL"
         run: "sudo /etc/init.d/mysql start"
@@ -61,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version:
-          - 7.4
-        typo3-version:
-          - ^10.4
+        include:
+          - typo3-version: ^10.4
+            php-version: 7.4
+            composer-dependencies: highest


### PR DESCRIPTION
Having a consistent structure and order between the CI jobs and the
code coverage generation job makes understanding the GitHub Actions
configuration easier.

It also allows having a shared Composer cache between the non-coverage
jobs and the coverage job.