### PR TITLE
[TASK] Move the coverage directories

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Generate coverage badge"
         uses: timkrase/phpunit-coverage-badge@v1.2.0
         with:
-          report: './coverage/clover.xml'
+          report: './build/logs/clover.xml'
           coverage_badge_path: './coverage/badge.svg'
       - name: "Commit PHPUnit coverage results"
         uses: s0/git-publish-subdir-action@develop

--- a/composer.json
+++ b/composer.json
@@ -106,9 +106,18 @@
 			"@ci:coverage:unit",
 			"@ci:coverage:functional"
 		],
-		"ci:coverage:functional": ".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml --whitelist Classes --coverage-php=coverage/functional.cov Tests/Functional",
-		"ci:coverage:merge": "@php tools/phpcov merge --clover=./coverage/clover.xml coverage/",
-		"ci:coverage:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml --whitelist Classes --coverage-php=coverage/unit.cov Tests/Unit",
+		"ci:coverage:functional": [
+			"@coverage:create-directories",
+			".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml --whitelist Classes --coverage-php=.Build/coverage/functional.cov Tests/Functional"
+		],
+		"ci:coverage:merge": [
+			"@coverage:create-directories",
+			"@php tools/phpcov merge --clover=./build/logs/clover.xml ./.Build/coverage/"
+		],
+		"ci:coverage:unit": [
+			"@coverage:create-directories",
+			".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
+		],
 		"ci:dynamic": [
 			"@ci:tests"
 		],
@@ -144,6 +153,7 @@
 		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml Tests/Unit",
 		"ci:ts:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*Resources/Private/node_modules/*' -name '*.yml' | xargs -r php ./.Build/vendor/bin/yaml-lint",
+		"coverage:create-directories": "mkdir -p build/logs .Build/coverage",
 		"docs:generate": [
 			"docker run --rm t3docs/render-documentation show-shell-commands > tempfile.sh; echo 'dockrun_t3rd makehtml' >> tempfile.sh; bash tempfile.sh; rm tempfile.sh"
 		],
@@ -201,6 +211,7 @@
 		"ci:tests:unit": "Runs the unit tests.",
 		"ci:ts:lint": "Lints the TypoScript files.",
 		"ci:yaml:lint": "Lints the YAML files.",
+		"coverage:create-directories": "Creates the directories needed for recording and merging the code coverage reports.",
 		"docs:generate": "Renders the extension ReST documentation.",
 		"fix:php": "Runs all fixers for the PHP code.",
 		"fix:php:cs": "Fixes the code style with PHP-CS-Fixer.",


### PR DESCRIPTION
There is no need to have the code coverage data directly generated by
the tests run in a non-hidden directory. So now the code coverage is
recorded within `.Build/coverage`.

Only the merged coverage data still needs to be located in `build/logs`
as Coveralls (which we're planning to use) relies on this.