### PR TITLE
[BUGFIX] Do not cache the `.Build` directory in GitLab CI

### DIFF
--- a/.gitlab/pipeline/jobs/build-composer-dependencies.yml
+++ b/.gitlab/pipeline/jobs/build-composer-dependencies.yml
@@ -16,4 +16,3 @@ build-composer-dependencies:
   cache:
     paths:
       - .composer
-      - .Build


### PR DESCRIPTION
We must not cache this directory. If it is cached, this might cause
Composer to (re-)install dependency version that are not valid for
the current PHP version, which possibly might break the build.