### PR TITLE
[BUGFIX] Mark the repository test as also covering the model

### DIFF
--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -15,6 +15,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
  * @covers \TTN\Tea\Domain\Repository\Product\TeaRepository
+ * @covers \TTN\Tea\Domain\Model\Product\Tea
  */
 class TeaRepositoryTest extends FunctionalTestCase
 {


### PR DESCRIPTION
We currently can only test the lazy loading of the model image
with a functional test that retrieves a model from the database
via the repository.

So the functional test for the repository also needs to be marked as
covering the model class to make our code coverage correct.