### PR TITLE
[TASK] Reduce and reorder the badges in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # Example TYPO3 extension for code quality checks and automated tests
 
-[![Latest stable version](https://poser.pugx.org/ttn/tea/v/stable.svg)](https://packagist.org/packages/ttn/tea)
-[![Total downloads](https://poser.pugx.org/ttn/tea/downloads.svg)](https://packagist.org/packages/ttn/tea)
-[![Monthly Downloads](https://poser.pugx.org/ttn/tea/d/monthly)](https://packagist.org/packages/ttn/tea)
 [![TYPO3 V10](https://img.shields.io/badge/TYPO3-10-orange.svg)](https://get.typo3.org/version/10)
 [![TYPO3 V11](https://img.shields.io/badge/TYPO3-11-orange.svg)](https://get.typo3.org/version/11)
+[![License](https://poser.pugx.org/ttn/tea/license.svg)](https://packagist.org/packages/ttn/tea)
+[![Total downloads](https://poser.pugx.org/ttn/tea/downloads.svg)](https://packagist.org/packages/ttn/tea)
 [![GitHub CI status](https://github.com/TYPO3-Documentation/tea/workflows/CI/badge.svg?branch=main)](https://github.com/TYPO3-Documentation/tea/actions)
 [![GitLab CI status](https://gitlab.typo3.org/qa/example-extension/badges/main/pipeline.svg)](https://gitlab.typo3.org/qa/example-extension/-/pipelines)
 [![Coverage Status](https://coveralls.io/repos/github/TYPO3-Documentation/tea/badge.svg?branch=main)](https://coveralls.io/github/TYPO3-Documentation/tea?branch=main)
-[![Total downloads](https://poser.pugx.org/ttn/tea/downloads.svg)](https://packagist.org/packages/ttn/tea)
-[![License](https://poser.pugx.org/ttn/tea/license.svg)](https://packagist.org/packages/ttn/tea)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 This TYPO3 extension, based on Extbase and Fluid, is an example of best
 practices in automated code checks, unit/functional/acceptance testing and


### PR DESCRIPTION
Reorder the badges so the TYPO3 versions come first and the
CI information latest (ordered from user-relevant to
developer-relevant).

Drop some badges to get the badges to fit in one line again:

- Drop the counter for this month's downloads (as this number
  fluctuated too much during the month).

- Drop a duplicate badge.

- Drop the badge for the old CoC (as we now are using the TYPO3 CoC).

- Drop the "latest version" badge (as this tends to be unreliable).