### PR TITLE
[CLEANUP] Remove type annotations for fields from the testing framework

### DIFF
--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -19,9 +19,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 class TeaRepositoryTest extends FunctionalTestCase
 {
-    /**
-     * @var array<int, non-empty-string>
-     */
     protected $testExtensionsToLoad = ['typo3conf/ext/tea'];
 
     /**


### PR DESCRIPTION
As in these cases the type annotations from the base class are used,
we can avoid PHPStan warnings about discrepancies between our annotations
and the annotations from the testing framework for the corresponding
fields in the superclass.