### PR TITLE
[BUGFIX] Treat PHP versions in the GitHub CI configuration as strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 7.2
-          - 7.3
-          - 7.4
-          - 8.0
-          - 8.1
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+          - "8.1"
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-22.04
@@ -70,7 +70,7 @@ jobs:
           - "ts:lint"
           - "yaml:lint"
         php-version:
-          - 7.4
+          - "7.4"
   code-quality-frontend:
     name: "Code quality frontend checks"
     runs-on: ubuntu-22.04
@@ -138,41 +138,41 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 7.4
+          - typo3-version: "^11.5"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 7.4
+          - typo3-version: "^11.5"
+            php-version: "7.4"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 8.0
+          - typo3-version: "^11.5"
+            php-version: "8.0"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 8.0
+          - typo3-version: "^11.5"
+            php-version: "8.0"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 8.1
+          - typo3-version: "^11.5"
+            php-version: "8.1"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 8.1
+          - typo3-version: "^11.5"
+            php-version: "8.1"
             composer-dependencies: lowest
   functional-tests:
     name: "Functional tests"
@@ -225,39 +225,39 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 7.4
+          - typo3-version: "^11.5"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 7.4
+          - typo3-version: "^11.5"
+            php-version: "7.4"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 8.0
+          - typo3-version: "^11.5"
+            php-version: "8.0"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 8.0
+          - typo3-version: "^11.5"
+            php-version: "8.0"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 8.1
+          - typo3-version: "^11.5"
+            php-version: "8.1"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 8.1
+          - typo3-version: "^11.5"
+            php-version: "8.1"
             composer-dependencies: lowest

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -65,6 +65,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: ^11.5
-            php-version: 7.4
+          - typo3-version: "^11.5"
+            php-version: "7.4"
             composer-dependencies: highest

--- a/.github/workflows/predefined.yml
+++ b/.github/workflows/predefined.yml
@@ -27,9 +27,9 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 7.2
-          - 7.3
-          - 7.4
+          - "7.2"
+          - "7.3"
+          - "7.4"
   typoscript-lint:
     name: "TypoScript linter"
     runs-on: ubuntu-22.04
@@ -123,7 +123,7 @@ jobs:
           - "composer:normalize"
           - "php:sniff"
         php-version:
-          - 7.4
+          - "7.4"
   code-quality-frontend:
     name: "Code quality frontend checks"
     runs-on: ubuntu-22.04
@@ -194,12 +194,12 @@ jobs:
           - highest
           - lowest
         php-version:
-          - 7.2
-          - 7.3
-          - 7.4
+          - "7.2"
+          - "7.3"
+          - "7.4"
         typo3-version:
-          - ^9.5
-          - ^10.4
+          - "^9.5"
+          - "^10.4"
   functional-tests:
     name: "Functional tests"
     runs-on: ubuntu-18.04
@@ -251,21 +251,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: lowest


### PR DESCRIPTION
PHP version numbers need to be strings: If the version `8.0` were
treated as a number, the YAML parser would happily convert it to `8`,
hence dropping the minor version number.