### PR TITLE
[BUGFIX] Block Dependabot from breaking upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
     allow:
       - dependency-type: "development"
     ignore:
+      - dependency-name: "ergebnis/composer-normalize"
+        versions: [ "^2.20" ]
+      - dependency-name: "phpunit/phpunit"
+        versions: [ "^9.0", "^10.0" ]
       - dependency-name: "symfony/yaml"
       - dependency-name: "typo3/cms-*"
     versioning-strategy: "increase"


### PR DESCRIPTION
composer-noramlize >= 2.2.0 will conflicts with our supported PHP
version range, as does PHPUnit 9.x (and 10.x will too).

So we need to configure Dependabot to stay below these breaking
versions.

Fixes #467