### PR TITLE
[BUGFIX] Do not overwrite type annotations from parent classes

### DIFF
--- a/Classes/Domain/Repository/Product/TeaRepository.php
+++ b/Classes/Domain/Repository/Product/TeaRepository.php
@@ -16,8 +16,5 @@ class TeaRepository extends Repository
 {
     use StoragePageAgnosticTrait;
 
-    /**
-     * @var string[]
-     */
     protected $defaultOrderings = ['title' => QueryInterface::ORDER_ASCENDING];
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^PHPDoc type array\\<string\\> of property TTN\\\\Tea\\\\Domain\\\\Repository\\\\Product\\\\TeaRepository\\:\\:\\$defaultOrderings is not the same as PHPDoc type array of overridden property TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Repository\\<TTN\\\\Tea\\\\Domain\\\\Model\\\\Product\\\\Tea\\>\\:\\:\\$defaultOrderings\\.$#"
-			count: 1
-			path: Classes/Domain/Repository/Product/TeaRepository.php


### PR DESCRIPTION
This avoids PHPStan warnings in a case where our type annotations are
not up to date anymore with the latest change in the Core.