### PR TITLE
[BUGFIX] Correct version constraints for PHP in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"docs": "https://docs.typo3.org/p/ttn/tea/main/en-us/"
 	},
 	"require": {
-		"php": "~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0 || ~8.1",
+		"php": "~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0",
 		"typo3/cms-core": "^10.4 || ^11.5.2",
 		"typo3/cms-extbase": "^10.4 || ^11.5.2",
 		"typo3/cms-fluid": "^10.4 || ^11.5.2",


### PR DESCRIPTION
~8.0 means >= 8.0.0 < 9.0.0
~8.1 means >= 8.1.0 < 9.0.0

What really is wanted:
~8.0.0 means >= 8.0.0 < 8.1.0
~8.1.0 means >= 8.1.0 < 8.2.0

See: https://getcomposer.org/doc/articles/versions.md#tilde-version-range-