### PR TITLE
[TASK] Update to Composer 2.4

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -18,7 +18,7 @@ hooks:
 omit_containers: [dba, ddev-ssh-agent]
 webimage_extra_packages: [parallel]
 use_dns_when_possible: true
-composer_version: "2.3.7"
+composer_version: "2.4"
 web_environment:
 - typo3DatabaseName=typo3
 - typo3DatabaseHost=db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.3
+          tools: composer:v2.4
       - name: "Run PHP lint"
         run: "composer ci:php:lint"
     strategy:
@@ -44,7 +44,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.3
+          tools: composer:v2.4
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -107,7 +107,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.3
+          tools: composer:v2.4
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -185,7 +185,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2.3
+          tools: composer:v2.4
           extensions: mysqli
           coverage: none
       - name: "Show Composer version"

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -17,7 +17,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2.3
+          tools: composer:v2.4
           extensions: xdebug, mysqli
           coverage: xdebug
       - name: "Show Composer version"

--- a/.github/workflows/predefined.yml
+++ b/.github/workflows/predefined.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.3
+          tools: composer:v2.4
       - name: "Run PHP lint"
         run: "composer ci:php:lint"
     strategy:
@@ -103,7 +103,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.3
+          tools: composer:v2.4
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -160,7 +160,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.3
+          tools: composer:v2.4
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -211,7 +211,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2.3
+          tools: composer:v2.4
           extensions: mysqli
           coverage: none
       - name: "Show Composer version"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Update to Composer 2.4 (#513)
 - Change the default indentation for rst files to 4 spaces (#194)
 
 ### Deprecated


### PR DESCRIPTION
Now that Composer 2.4 has had its first point release, we can safely
upgrade from 2.3 to 2.4 in the DDEV configuration and the CI pipeline.