### PR TITLE
[TASK] Allow dev installations with Doctrine 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"typo3/cms-frontend": "^10.4 || ^11.5.2"
 	},
 	"require-dev": {
-		"doctrine/dbal": "^2.13.8",
+		"doctrine/dbal": "^2.13.8 || ^3.3.7",
 		"ergebnis/composer-normalize": "^2.19.0",
 		"friendsofphp/php-cs-fixer": "^3.4.0",
 		"helmich/typo3-typoscript-lint": "^2.5.2",


### PR DESCRIPTION
TYPO3 12LTS will require Doctrine ^3.3.7 (or possibly even higher).

To not block this, our development requirement of Doctrine needs to
allow Doctrine 3 as well.