### PR TITLE
[TASK] Stop using the `typo3/minimal` package on CI

### DIFF
--- a/.gitlab/pipeline/jobs/func-php7.2-v10.yml
+++ b/.gitlab/pipeline/jobs/func-php7.2-v10.yml
@@ -7,5 +7,5 @@ func-php7.2-v10:
   needs:
     - php-lint-php7.2
   script:
-    - composer require --prefer-dist --no-progress typo3/minimal:"^10.4"
+    - composer require --prefer-dist --no-progress typo3/cms-core:"^10.4"
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php7.3-v10.yml
+++ b/.gitlab/pipeline/jobs/func-php7.3-v10.yml
@@ -8,5 +8,5 @@ func-php7.3-v10:
     - build-composer-dependencies
     - php-lint-php7.3
   script:
-    - composer require --no-progress typo3/minimal:"^10.4"
+    - composer require --no-progress typo3/cms-core:"^10.4"
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php7.4-v10.yml
+++ b/.gitlab/pipeline/jobs/func-php7.4-v10.yml
@@ -8,5 +8,5 @@ func-php7.4-v10:
     - build-composer-dependencies
     - php-lint-php7.4
   script:
-    - composer require --no-progress typo3/minimal:"^10.4"
+    - composer require --no-progress typo3/cms-core:"^10.4"
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/unit-php7.2-v10.yml
+++ b/.gitlab/pipeline/jobs/unit-php7.2-v10.yml
@@ -5,5 +5,5 @@ unit-php7.2-v10:
   needs:
     - php-lint-php7.2
   script:
-    - composer require --prefer-dist --no-progress typo3/minimal:"^10.4"
+    - composer require --prefer-dist --no-progress typo3/cms-core:"^10.4"
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php7.3-v10.yml
+++ b/.gitlab/pipeline/jobs/unit-php7.3-v10.yml
@@ -6,5 +6,5 @@ unit-php7.3-v10:
     - build-composer-dependencies
     - php-lint-php7.3
   script:
-    - composer require --no-progress typo3/minimal:"^10.4"
+    - composer require --no-progress typo3/cms-core:"^10.4"
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php7.4-v10.yml
+++ b/.gitlab/pipeline/jobs/unit-php7.4-v10.yml
@@ -6,5 +6,5 @@ unit-php7.4-v10:
     - build-composer-dependencies
     - php-lint-php7.4
   script:
-    - composer require --no-progress typo3/minimal:"^10.4"
+    - composer require --no-progress typo3/cms-core:"^10.4"
     - composer ci:tests:unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Use CamelCase for the TsConfig folder (#522)
-- Stop using the `typo3/minimal` package on CI (#520)
+- Stop using the `typo3/minimal` package on CI (#520, #531)
 - Update to Composer 2.4 (#513)
 - Change the default indentation for rst files to 4 spaces (#194)
 


### PR DESCRIPTION
The `typo3/minimal` package is not maintained very much, and currently
cannot be used as a requirement to install the latest TYPO3 development
version (as it still depends on `dev-master`, not on `dev-main`).

In addition, not depending on it will allow us to find any missing
dependencies in our requirements that so far have been masked by
the `typo3/minimal` dependencies.

(This is the same as #520, but for GitLab CI.)