### PR TITLE
[TASK] Also mock `redirectToUri` in the controller unit test

### DIFF
--- a/Tests/Unit/Controller/TeaControllerTest.php
+++ b/Tests/Unit/Controller/TeaControllerTest.php
@@ -41,7 +41,7 @@ class TeaControllerTest extends UnitTestCase
         parent::setUp();
 
         // We need to create an accessible mock in order to be able to set the protected `view`.
-        $this->subject = $this->getAccessibleMock(TeaController::class, ['redirect', 'forward']);
+        $this->subject = $this->getAccessibleMock(TeaController::class, ['forward', 'redirect', 'redirectToUri']);
 
         $this->viewProphecy = $this->prophesize(TemplateView::class);
         $view = $this->viewProphecy->reveal();


### PR DESCRIPTION
Now all methods that conceptually should not be part of a controller
(and that hence must never be executed in a unit test)
are mocked for consistency.

Also sort the method names.

Fixes #446