### PR TITLE
[TASK] Switch Dependabot PR target milestone to the 3.0 milestone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    milestone: 5
+    milestone: 7
 
   - package-ecosystem: "composer"
     directory: "/"
@@ -20,11 +20,11 @@ updates:
       - dependency-name: "symfony/yaml"
       - dependency-name: "typo3/cms-*"
     versioning-strategy: "increase"
-    milestone: 5
+    milestone: 7
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
     versioning-strategy: "increase"
-    milestone: 5
+    milestone: 7


### PR DESCRIPTION
The PRs now should target 3.0.0, not 2.0.1 anymore, as 2.0.1 is out of the door, and we're working on 3.0 now.

Fixes #583