### PR TITLE
[TASK] Update ergebnis/composer-normalize

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
     allow:
       - dependency-type: "development"
     ignore:
-      - dependency-name: "ergebnis/composer-normalize"
-        versions: [ "^2.20" ]
       - dependency-name: "phpunit/phpunit"
         versions: [ "^9.0", "^10.0" ]
       - dependency-name: "symfony/yaml"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 	},
 	"require-dev": {
 		"doctrine/dbal": "^2.13.8 || ^3.3.7",
-		"ergebnis/composer-normalize": "^2.19.0",
+		"ergebnis/composer-normalize": "^2.28.3",
 		"friendsofphp/php-cs-fixer": "^3.4.0",
 		"helmich/typo3-typoscript-lint": "^2.5.2",
 		"jangregor/phpstan-prophecy": "^1.0.0",


### PR DESCRIPTION
Also remove the update block from the Dependabot configuration (now that we require PHP >= 7.4., which allows for current versions of this package).