### PR TITLE
[CLEANUP] Use typed properties instead of `@var` annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Use typed properties instead of `@var` annotations (#599)
 - Return `ResponseInterface` in controller actions (#597)
 - Replace switchable controller actions with separate plugins (#575)
 

--- a/Classes/Controller/TeaController.php
+++ b/Classes/Controller/TeaController.php
@@ -14,10 +14,7 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  */
 class TeaController extends ActionController
 {
-    /**
-     * @var TeaRepository
-     */
-    private $teaRepository;
+    private TeaRepository $teaRepository;
 
     public function injectTeaRepository(TeaRepository $teaRepository): void
     {

--- a/Classes/Domain/Model/Product/Tea.php
+++ b/Classes/Domain/Model/Product/Tea.php
@@ -14,15 +14,9 @@ use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
  */
 class Tea extends AbstractEntity
 {
-    /**
-     * @var string
-     */
-    protected $title = '';
+    protected string $title = '';
 
-    /**
-     * @var string
-     */
-    protected $description = '';
+    protected string $description = '';
 
     /**
      * @phpstan-var \TYPO3\CMS\Extbase\Domain\Model\FileReference|LazyLoadingProxy|null

--- a/Classes/Domain/Repository/Traits/StoragePageAgnosticTrait.php
+++ b/Classes/Domain/Repository/Traits/StoragePageAgnosticTrait.php
@@ -14,10 +14,7 @@ use TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface;
  */
 trait StoragePageAgnosticTrait
 {
-    /**
-     * @var QuerySettingsInterface
-     */
-    private $querySettings;
+    private QuerySettingsInterface $querySettings;
 
     public function injectQuerySettings(QuerySettingsInterface $querySettings): void
     {

--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -21,15 +21,9 @@ class TeaRepositoryTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = ['typo3conf/ext/tea'];
 
-    /**
-     * @var TeaRepository
-     */
-    private $subject;
+    private TeaRepository $subject;
 
-    /**
-     * @var PersistenceManager
-     */
-    private $persistenceManager;
+    private PersistenceManager $persistenceManager;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Domain/Model/Product/TeaTest.php
+++ b/Tests/Unit/Domain/Model/Product/TeaTest.php
@@ -14,10 +14,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 class TeaTest extends UnitTestCase
 {
-    /**
-     * @var Tea
-     */
-    private $subject;
+    private Tea $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/Product/TeaRepositoryTest.php
@@ -14,10 +14,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 class TeaRepositoryTest extends UnitTestCase
 {
-    /**
-     * @var TeaRepository
-     */
-    private $subject;
+    private TeaRepository $subject;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
The `@var` annotations where left where it is not possible yet to replace them in PHP 7.4.

Fixes #550