### PR TITLE
[BUGFIX] Stop relying on transitive dependencies for `psr/http-message`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.2 and 7.3 (#581)
 
 ### Fixed
+- Stop relying on transitive dependencies for `psr/http-message` (#613)
 
 ## 2.0.1
 

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
 	},
 	"require": {
 		"php": "~7.4.0 || ~8.0.0 || ~8.1.0",
+		"psr/http-message": "^1.0.1",
 		"typo3/cms-core": "^11.5.2",
 		"typo3/cms-extbase": "^11.5.2",
 		"typo3/cms-fluid": "^11.5.2",


### PR DESCRIPTION
We're using a class from this package in the controller and hence should have this package as a direct dependency.