### PR TITLE
[TASK] Have the lowest dependencies above the highest on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,22 +144,22 @@ jobs:
         include:
           - typo3-version: "^11.5"
             php-version: "7.4"
-            composer-dependencies: highest
+            composer-dependencies: lowest
           - typo3-version: "^11.5"
             php-version: "7.4"
-            composer-dependencies: lowest
-          - typo3-version: "^11.5"
-            php-version: "8.0"
             composer-dependencies: highest
           - typo3-version: "^11.5"
             php-version: "8.0"
             composer-dependencies: lowest
           - typo3-version: "^11.5"
-            php-version: "8.1"
+            php-version: "8.0"
             composer-dependencies: highest
           - typo3-version: "^11.5"
             php-version: "8.1"
             composer-dependencies: lowest
+          - typo3-version: "^11.5"
+            php-version: "8.1"
+            composer-dependencies: highest
   functional-tests:
     name: "Functional tests"
     runs-on: ubuntu-22.04
@@ -220,19 +220,19 @@ jobs:
         include:
           - typo3-version: "^11.5"
             php-version: "7.4"
-            composer-dependencies: highest
+            composer-dependencies: lowest
           - typo3-version: "^11.5"
             php-version: "7.4"
-            composer-dependencies: lowest
-          - typo3-version: "^11.5"
-            php-version: "8.0"
             composer-dependencies: highest
           - typo3-version: "^11.5"
             php-version: "8.0"
             composer-dependencies: lowest
           - typo3-version: "^11.5"
-            php-version: "8.1"
+            php-version: "8.0"
             composer-dependencies: highest
           - typo3-version: "^11.5"
             php-version: "8.1"
             composer-dependencies: lowest
+          - typo3-version: "^11.5"
+            php-version: "8.1"
+            composer-dependencies: highest


### PR DESCRIPTION
This way, the Composer dependencies are consistently in ascending order in the CI matrix (as are the PHP and TYPO3 versions).

Fixes #578