### PR TITLE
[TASK] Upgrade `friendsofphp/php-cs-fixer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 	"require-dev": {
 		"doctrine/dbal": "^2.13.8 || ^3.3.7",
 		"ergebnis/composer-normalize": "^2.28.3",
-		"friendsofphp/php-cs-fixer": "^3.4.0",
+		"friendsofphp/php-cs-fixer": "^3.11.0",
 		"helmich/typo3-typoscript-lint": "^2.5.2",
 		"jangregor/phpstan-prophecy": "^1.0.0",
 		"php-coveralls/php-coveralls": "^2.5.3",
@@ -61,7 +61,6 @@
 	},
 	"conflict": {
 		"doctrine/dbal": "2.13.1",
-		"friendsofphp/php-cs-fixer": "3.5.0",
 		"typo3/class-alias-loader": "< 1.1.0"
 	},
 	"prefer-stable": true,


### PR DESCRIPTION
With PHP 7.4 as the minimum supported PHP version, we can now upgrade.

Also drop a now-obsolete conflict for a package version that now is not possible anymore.