### PR TITLE
[TASK] Have the lowest dependencies above the highest on CI

### DIFF
--- a/.github/workflows/predefined.yml
+++ b/.github/workflows/predefined.yml
@@ -193,22 +193,22 @@ jobs:
         include:
           - typo3-version: "^11.5"
             php-version: "7.4"
-            composer-dependencies: highest
+            composer-dependencies: lowest
           - typo3-version: "^11.5"
             php-version: "7.4"
-            composer-dependencies: lowest
-          - typo3-version: "^11.5"
-            php-version: "8.0"
             composer-dependencies: highest
           - typo3-version: "^11.5"
             php-version: "8.0"
             composer-dependencies: lowest
           - typo3-version: "^11.5"
-            php-version: "8.1"
+            php-version: "8.0"
             composer-dependencies: highest
           - typo3-version: "^11.5"
             php-version: "8.1"
             composer-dependencies: lowest
+          - typo3-version: "^11.5"
+            php-version: "8.1"
+            composer-dependencies: highest
   functional-tests:
     name: "Functional tests"
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This way, the Composer dependencies are consistently in ascending order in the CI matrix (as are the PHP and TYPO3 versions).

This is the same as #617 (which rearranged the CI matrix entries for the Composer-script-based CI jobs), but for the CI jobs using the predefined GitHub Actions (this time for the unit tests).

Part of #578