### PR TITLE
[BUGFIX] Exclude `doctrine/dbal` from Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
     allow:
       - dependency-type: "development"
     ignore:
+      - dependency-name: "doctrine/dbal"
       - dependency-name: "phpunit/phpunit"
         versions: [ "^10.0" ]
       - dependency-name: "symfony/yaml"


### PR DESCRIPTION
Dependabot cannot handle multi-version dependencies and would happily throw away one of allowed versions (like in #626).