### PR TITLE
[TASK] Add the testing framework bridge as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
 		"phpstan/phpstan-strict-rules": "^1.4.4",
 		"phpunit/phpunit": "^9.5.25",
 		"saschaegerer/phpstan-typo3": "^1.1.2",
+		"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.0.1",
 		"seld/jsonlint": "^1.9.0",
 		"squizlabs/php_codesniffer": "^3.7.1",
 		"symfony/yaml": "^5.4 || ^6.1",
@@ -77,6 +78,7 @@
 		"allow-plugins": {
 			"ergebnis/composer-normalize": true,
 			"phpstan/extension-installer": true,
+			"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": true,
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true
 		},


### PR DESCRIPTION
This is required to get the tests to work with typo3/composer-installers V4/V5.