### PR TITLE
[BUGFIX] Do not check `composer.lock` during `composer normalize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.2 and 7.3 (#581)
 
 ### Fixed
+- Do not check `composer.lock` during `composer normalize` (#641)
 - Require TYPO3 >= 11.5.4 (#643)
 - Stop relying on transitive dependencies for `psr/http-message` (#613)
 

--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
 		"ci": [
 			"@ci:static"
 		],
-		"ci:composer:normalize": "@composer normalize --dry-run",
+		"ci:composer:normalize": "@composer normalize --no-check-lock --dry-run",
 		"ci:coverage": [
 			"@ci:coverage:unit",
 			"@ci:coverage:functional"


### PR DESCRIPTION
This package does not ship a `composer.lock`, and hence `composer normalize` should not check that file.

Fixes #640