### PR TITLE
[TASK] Add `.gitignore` entry for JetBrains Fleet editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /*.idea
 /.Build/*
+/.fleet
 /.php-cs-fixer.cache
 /.phpunit.result.cache
 /Documentation-GENERATED-temp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add `.gitignore` entry for JetBrains Fleet editor (#642)
 
 ### Changed
 - Upgrade to the testing framework v7 (#629)


### PR DESCRIPTION
JetBrains created a new product named "Fleet" as
lightweight editor. This tool tends to write it's
config files to `.fleet/` folders, like all of the IntellJ based IDE's like PHPStorm uses the `.idea` folder.

This change adds this config folder to `.gitignore` to avoid adding this folder to a patch if Fleet
is used to create a patch.