### PR TITLE
[TASK] Upgrade to `helmich/typo3-typoscript-lint` V3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Upgrade to `helmich/typo3-typoscript-lint` V3 (#645)
 - Upgrade to the testing framework v7 (#629)
 - Make the TCA ready for TYPO3 v12 (#625)
 - Upgrade to PHPUnit 9 and PHPCOV 8 (#610)

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 		"doctrine/dbal": "^2.13.8 || ^3.3.7",
 		"ergebnis/composer-normalize": "^2.28.3",
 		"friendsofphp/php-cs-fixer": "^3.12.0",
-		"helmich/typo3-typoscript-lint": "^2.5.2",
+		"helmich/typo3-typoscript-lint": "^3.0.0",
 		"jangregor/phpstan-prophecy": "^1.0.0",
 		"php-coveralls/php-coveralls": "^2.5.3",
 		"phpspec/prophecy": "^1.15.0",


### PR DESCRIPTION
This unblocks the road to Symfony 6 (which is required for TYPO3 12).