### PR TITLE
[TASK] Avoid race condition on case-insensitive filesystems

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -70,7 +70,7 @@ jobs:
       - name: "Upload coverage results to Coveralls"
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./.Build/vendor/bin/php-coveralls --coverage_clover=build/logs/clover.xml -v
+        run: ./.Build/vendor/bin/php-coveralls --coverage_clover=./.Build/logs/clover.xml --json_path=./.Build/logs/coveralls-upload.json -v
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /.php-cs-fixer.cache
 /.phpunit.result.cache
 /Documentation-GENERATED-temp/
-/build
 /clover.xml
 /composer.lock
 /nbproject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Avoid race condition on case-insensitive filesystems (#657)
 
 ## 3.0.0
 

--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,7 @@
 		],
 		"ci:coverage:merge": [
 			"@coverage:create-directories",
-			"@php tools/phpcov merge --clover=./build/logs/clover.xml ./.Build/coverage/"
+			"@php tools/phpcov merge --clover=./.Build/logs/clover.xml ./.Build/coverage/"
 		],
 		"ci:coverage:unit": [
 			"@coverage:create-directories",
@@ -157,7 +157,7 @@
 		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml Tests/Unit",
 		"ci:ts:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' -regextype egrep -regex '.*.ya?ml$' | xargs -r php ./.Build/vendor/bin/yaml-lint",
-		"coverage:create-directories": "mkdir -p build/logs .Build/coverage",
+		"coverage:create-directories": "mkdir -p .Build/logs .Build/coverage",
 		"docs:generate": [
 			"docker run --rm t3docs/render-documentation show-shell-commands > tempfile.sh; echo 'dockrun_t3rd makehtml' >> tempfile.sh; bash tempfile.sh; rm tempfile.sh"
 		],


### PR DESCRIPTION
Case-insensitive filesystems cannot distinguish properly for file and folder names with different casings. This leads to unforseeable issues on these systems, like default partition on MacOS devices from apple or eventually Windows systems.

This change configure phpcoverall and the chain explicitly to use folders for the files which differs from the default of `build/*` to avoid conflicts on case-insensitve filesystems and prepare for introduction of the upcoming implementation of TYPO3 core recommended `Build/` structure.