### PR TITLE
[CLEANUP] Use short class references in the domain model annotations

### DIFF
--- a/Classes/Domain/Model/Product/Tea.php
+++ b/Classes/Domain/Model/Product/Tea.php
@@ -19,8 +19,8 @@ class Tea extends AbstractEntity
     protected string $description = '';
 
     /**
-     * @phpstan-var \TYPO3\CMS\Extbase\Domain\Model\FileReference|LazyLoadingProxy|null
-     * @var \TYPO3\CMS\Extbase\Domain\Model\FileReference|null
+     * @phpstan-var FileReference|LazyLoadingProxy|null
+     * @var FileReference|null
      * @Lazy
      */
     protected $image;


### PR DESCRIPTION
Starting with TYPO3 10LTS, it is no longer necessary to use FQCNs for domain property annotations for Extbase.