### PR TITLE
[BUGFIX] Get the functional tests to work with TYPO3 >= 12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Stop using Prophecy (#676)
 
 ### Fixed
+- Get the functional tests to work with TYPO3 >= 12.1 (#704)
 - Avoid race condition on case-insensitive filesystems (#657)
 
 ## 3.0.0

--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -6,6 +6,8 @@ namespace TTN\Tea\Tests\Functional\Domain\Repository\Product;
 
 use TTN\Tea\Domain\Model\Product\Tea;
 use TTN\Tea\Domain\Repository\Product\TeaRepository;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -26,6 +28,11 @@ class TeaRepositoryTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // This is needed to make the functional tests work with TYPO3 12.1. We might be able to remove this in the
+        // once we've updated to TYPO3 12.1.3 or 12.2.
+        $request = (new ServerRequest())->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_CLI);
+        $GLOBALS['TYPO3_REQUEST'] = $request;
 
         $this->persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
 


### PR DESCRIPTION
Starting with TYPO3 12.1, a request is required for the `BackendConfigurationManager` to not crash:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/76447

Also, a fix in that area has been merged (after the release of TYPO3 12.1) that might allow us to remove our workaround again once we've updated to TYPO3 12.2 or 12.1.3:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/77028