### PR TITLE
[FEATURE] Add automerging of green Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,3 +250,19 @@ jobs:
           - typo3-version: "^12.2"
             php-version: "8.1"
             composer-dependencies: highest
+  automerge:
+    name: Dependabot auto-merge
+    runs-on: ubuntu-22.04
+    needs: [ php-lint, code-quality, code-quality-frontend, unit-tests, functional-tests ]
+    if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request_target' }}
+    steps:
+      - name: automerge
+        uses: pascalgn/automerge-action@v0.15.6
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_ERROR_FAIL: true
+          MERGE_LABELS: "dependencies,!blocked,!wip"
+          MERGE_METHOD: "rebase"
+          MERGE_READY_STATE: "clean,unstable"
+          MERGE_RETRIES: 0
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add automerging of green Dependabot PRs (#756)
 
 ### Changed
 - Set the minimal 12LTS version to 12.1 (#702)


### PR DESCRIPTION
Now dependency updates by Dependabot will be automerged if/when all required checks are green.

This will reduce the repetetive work of merging all these update PRs, and we have been heavily relying on our CI pipeline to check if a depenceny update is safe to merge anyway.

Attaching any of the labels `wip` or `blocked` to a PR will block the automerging.