### PR TITLE
[TASK] Switch to using GitHub's own automerge feature

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,17 @@
+name: automerge
+on:
+  pull_request_target:
+
+jobs:
+  automerge:
+    name: Dependabot auto-merge
+
+    runs-on: ubuntu-22.04
+
+    if: ${{ github.actor == 'dependabot[bot]' }}
+
+    steps:
+      - uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,19 +251,3 @@ jobs:
           - typo3-version: "^12.2"
             php-version: "8.1"
             composer-dependencies: highest
-  automerge:
-    name: Dependabot auto-merge
-    runs-on: ubuntu-22.04
-    needs: [ php-lint, code-quality, code-quality-frontend, unit-tests, functional-tests ]
-    if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request_target' }}
-    steps:
-      - name: automerge
-        uses: pascalgn/automerge-action@v0.15.6
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_ERROR_FAIL: true
-          MERGE_LABELS: "dependencies,!blocked,!wip"
-          MERGE_METHOD: "rebase"
-          MERGE_READY_STATE: "clean,unstable"
-          MERGE_RETRIES: 0
-


### PR DESCRIPTION
Our current automerging CI task does not work reliably.

So instead of using a GitHub Action that does the automerging itself, we are now using a GitHub Action that only triggers GitHub's own automerge feature (which works a lot more reliably).