### PR TITLE
[TASK] Use the GitHub command line tool for automerges

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,5 +1,8 @@
 name: automerge
+
 on:
+  # We're using pull_request_target instead of pull_request due to permission issues with the pull_request target:
+  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
   pull_request_target:
 
 jobs:
@@ -11,7 +14,8 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
 
     steps:
-      - uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          pull-request-number: ${{ github.event.pull_request.number }}
-          merge-method: squash
+      - name: Enable automerge
+        shell: bash
+        run: gh pr merge -R "${{ github.repository }}" --squash --auto "${{ github.event.pull_request.number }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This way, we do not need to rely on a 3rd-party GitHub action for this anymore.