### PR TITLE
[FEATURE] Automatically approve Dependabot pull requests

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,29 @@
+# https://docs.github.com/en/github-ae@latest/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+name: auto-approve
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    name: Dependabot auto-approve
+
+    runs-on: ubuntu-22.04
+
+    if: ${{ github.actor == 'dependabot[bot]' }}
+
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve the PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This way, we can enforce having an approval before a PR is allowed to get merged.