### PR TITLE
[CLEANUP] Reorder the type annotations for better readability

### DIFF
--- a/Classes/Domain/Model/Product/Tea.php
+++ b/Classes/Domain/Model/Product/Tea.php
@@ -19,8 +19,8 @@ class Tea extends AbstractEntity
     protected string $description = '';
 
     /**
-     * @phpstan-var FileReference|LazyLoadingProxy|null
      * @var FileReference|null
+     * @phpstan-var FileReference|LazyLoadingProxy|null
      * @Lazy
      */
     protected $image;


### PR DESCRIPTION
Apart from this small polish, there is nothing to change in order to be consistent with the latest decision on type annotations as described here:

https://decisions.typo3.org/t/phpstan-specific-phpdoc-annotations-in-the-core-code-base/807

Fixes #794