### PR TITLE
[TASK] Bump the TYPO3 12 dependency from ^12.3 to ^12.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,16 +169,16 @@ jobs:
           - typo3-version: "^11.5"
             php-version: "8.2"
             composer-dependencies: highest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: lowest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: highest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.2"
             composer-dependencies: lowest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.2"
             composer-dependencies: highest
   functional-tests:
@@ -263,15 +263,15 @@ jobs:
           - typo3-version: "^11.5"
             php-version: "8.2"
             composer-dependencies: highest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: lowest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: highest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.2"
             composer-dependencies: lowest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.2"
             composer-dependencies: highest

--- a/.github/workflows/predefined.yml
+++ b/.github/workflows/predefined.yml
@@ -209,16 +209,16 @@ jobs:
           - typo3-version: "^11.5"
             php-version: "8.2"
             composer-dependencies: highest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: lowest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: highest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.2"
             composer-dependencies: lowest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.2"
             composer-dependencies: highest
   functional-tests:
@@ -301,15 +301,15 @@ jobs:
           - typo3-version: "^11.5"
             php-version: "8.2"
             composer-dependencies: highest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: lowest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: highest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.2"
             composer-dependencies: lowest
-          - typo3-version: "^12.3"
+          - typo3-version: "^12.4"
             php-version: "8.2"
             composer-dependencies: highest

--- a/.gitlab/pipeline/jobs/func-php8.1-v12-highest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.1-v12-highest.yml
@@ -8,6 +8,6 @@ func-php8.1-v11-highest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
-    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.3"
+    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.1-v12-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.1-v12-lowest.yml
@@ -8,6 +8,6 @@ func-php8.1-v11-lowest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
-    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.3"
+    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.2-v12-highest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.2-v12-highest.yml
@@ -8,6 +8,6 @@ func-php8.2-v11-highest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
-    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.3"
+    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.2-v12-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.2-v12-lowest.yml
@@ -8,6 +8,6 @@ func-php8.2-v11-lowest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
-    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.3"
+    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/unit-php8.1-v12-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.1-v12-highest.yml
@@ -6,5 +6,5 @@ unit-php8.1-v12-highest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
-    - composer require --no-progress typo3/cms-core:"^12.3"
+    - composer require --no-progress typo3/cms-core:"^12.4"
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.1-v12-lowest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.1-v12-lowest.yml
@@ -6,6 +6,6 @@ unit-php8.1-v12-lowest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
-    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.3"
+    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.2-v12-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.2-v12-highest.yml
@@ -6,5 +6,5 @@ unit-php8.2-v12-highest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
-    - composer require --no-progress typo3/cms-core:"^12.3"
+    - composer require --no-progress typo3/cms-core:"^12.4"
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.2-v12-lowest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.2-v12-lowest.yml
@@ -6,6 +6,6 @@ unit-php8.2-v12-lowest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
-    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.3"
+    - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - composer ci:tests:unit

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
 	"require": {
 		"php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0",
 		"psr/http-message": "^1.0.1",
-		"typo3/cms-core": "^11.5.4 || ^12.3",
-		"typo3/cms-extbase": "^11.5.4 || ^12.3",
-		"typo3/cms-fluid": "^11.5.4 || ^12.3",
-		"typo3/cms-frontend": "^11.5.4 || ^12.3"
+		"typo3/cms-core": "^11.5.4 || ^12.4",
+		"typo3/cms-extbase": "^11.5.4 || ^12.4",
+		"typo3/cms-fluid": "^11.5.4 || ^12.4",
+		"typo3/cms-frontend": "^11.5.4 || ^12.4"
 	},
 	"require-dev": {
 		"doctrine/dbal": "^2.13.8 || ^3.3.7",
@@ -50,7 +50,7 @@
 		"seld/jsonlint": "^1.9.0",
 		"squizlabs/php_codesniffer": "^3.7.2",
 		"symfony/yaml": "^5.4 || ^6.1",
-		"typo3/cms-fluid-styled-content": "^11.5.4 || ^12.3",
+		"typo3/cms-fluid-styled-content": "^11.5.4 || ^12.4",
 		"typo3/coding-standards": "^0.6.1",
 		"typo3/testing-framework": "^7.0@dev"
 	},


### PR DESCRIPTION
TYPO3 12.4 AKA 12LTS has been released.