### PR TITLE
[TASK] Make the development dependencies more specific

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"typo3/cms-frontend": "^11.5.4 || ^12.4"
 	},
 	"require-dev": {
-		"doctrine/dbal": "^2.13.8 || ^3.3.7",
+		"doctrine/dbal": "^2.13.5 || ^3.6.2",
 		"ergebnis/composer-normalize": "^2.28.3",
 		"friendsofphp/php-cs-fixer": "^3.14.1",
 		"helmich/typo3-typoscript-lint": "^3.1.0",
@@ -48,8 +48,8 @@
 		"saschaegerer/phpstan-typo3": "^1.8.4",
 		"seld/jsonlint": "^1.9.0",
 		"squizlabs/php_codesniffer": "^3.7.2",
-		"symfony/yaml": "^5.4 || ^6.1",
-		"typo3/cms-fluid-styled-content": "^11.5.4 || ^12.4",
+		"symfony/yaml": "^5.3.6 || ^6.2.0",
+		"typo3/cms-fluid-styled-content": "^11.5.4 || ^12.4.0",
 		"typo3/coding-standards": "^0.6.1",
 		"typo3/testing-framework": "^7.0.1"
 	},


### PR DESCRIPTION
Even for a constraint like `^6.2`, we explicitly state the bug-fix version `^6.2.0`. Even though this is semantically the same, this communicates to the human reader that we explicitly allow version 6.2.0 instead of "any 6.2 version".

For dev dependencies that are also transitive dependencies of `typo3/cms-core`, align our dependencies with the `typo3/cms-core` dependencies. This allows us to catch bugs with the lowest dependencies that would go unnoticed if we required a higher version as a dev depdency.