### PR TITLE
[TASK] Cleanup ext_localconf.php

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,31 +1,34 @@
 <?php
 
+declare(strict_types=1);
+
+use TTN\Tea\Controller\TeaController;
+use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
+
 defined('TYPO3') or die('Access denied.');
 
-(static function (): void {
-    // This makes the plugin available for front-end rendering.
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        // extension name, matching the PHP namespaces (but without the vendor)
-        'Tea',
-        // arbitrary, but unique plugin name (not visible in the BE)
-        'TeaIndex',
-        // all actions
-        [
-            \TTN\Tea\Controller\TeaController::class => 'index',
-        ],
-        // non-cacheable actions
-        [
-            \TTN\Tea\Controller\TeaController::class => '',
-        ]
-    );
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'Tea',
-        'TeaShow',
-        [
-            \TTN\Tea\Controller\TeaController::class => 'show',
-        ],
-        [
-            \TTN\Tea\Controller\TeaController::class => '',
-        ]
-    );
-})();
+// This makes the plugin available for front-end rendering.
+ExtensionUtility::configurePlugin(
+// extension name, matching the PHP namespaces (but without the vendor)
+    'Tea',
+    // arbitrary, but unique plugin name (not visible in the BE)
+    'TeaIndex',
+    // all actions
+    [
+        TeaController::class => 'index',
+    ],
+    // non-cacheable actions
+    [
+        TeaController::class => '',
+    ]
+);
+ExtensionUtility::configurePlugin(
+    'Tea',
+    'TeaShow',
+    [
+        TeaController::class => 'show',
+    ],
+    [
+        TeaController::class => '',
+    ]
+);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -9,7 +9,7 @@ defined('TYPO3') or die('Access denied.');
 
 // This makes the plugin available for front-end rendering.
 ExtensionUtility::configurePlugin(
-// extension name, matching the PHP namespaces (but without the vendor)
+    // extension name, matching the PHP namespaces (but without the vendor)
     'Tea',
     // arbitrary, but unique plugin name (not visible in the BE)
     'TeaIndex',


### PR DESCRIPTION
After dropping TYPO3 10.4 support:

- Using an anonymous function is not needed anymore
- declare(strict_types=1); can and should be used
- Use statements instead of FQN should be used

resolves https://github.com/TYPO3-Documentation/tea/issues/826