### PR TITLE
[FEATURE] Add `Tea.ownerUid`

### DIFF
--- a/Classes/Domain/Model/Product/Tea.php
+++ b/Classes/Domain/Model/Product/Tea.php
@@ -25,6 +25,13 @@ class Tea extends AbstractEntity
      */
     protected $image;
 
+    // Note: We cannot use `@var` for the more specific type annotation here as this confuses the Extbase type mapper.
+
+    /**
+     * @phpstan-var int<0, max>
+     */
+    protected int $ownerUid = 0;
+
     public function getTitle(): string
     {
         return $this->title;
@@ -59,5 +66,21 @@ class Tea extends AbstractEntity
     public function setImage(FileReference $image): void
     {
         $this->image = $image;
+    }
+
+    /**
+     * @return int<0, max>
+     */
+    public function getOwnerUid(): int
+    {
+        return $this->ownerUid;
+    }
+
+    /**
+     * @param int<0, max> $ownerUid
+     */
+    public function setOwnerUid(int $ownerUid): void
+    {
+        $this->ownerUid = $ownerUid;
     }
 }

--- a/Classes/Domain/Repository/Product/TeaRepository.php
+++ b/Classes/Domain/Repository/Product/TeaRepository.php
@@ -7,6 +7,7 @@ namespace TTN\Tea\Domain\Repository\Product;
 use TTN\Tea\Domain\Model\Product\Tea;
 use TTN\Tea\Domain\Repository\Traits\StoragePageAgnosticTrait;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
@@ -17,4 +18,15 @@ class TeaRepository extends Repository
     use StoragePageAgnosticTrait;
 
     protected $defaultOrderings = ['title' => QueryInterface::ORDER_ASCENDING];
+
+    /**
+     * @param positive-int $ownerUid
+     */
+    public function findByOwnerUid(int $ownerUid): QueryResultInterface
+    {
+        $query = $this->createQuery();
+        $query->matching($query->equals('ownerUid', $ownerUid));
+
+        return $query->execute();
+    }
 }

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    \TTN\Tea\Domain\Model\Product\Tea::class => [
+        'properties' => [
+            'ownerUid' => ['fieldName' => 'owner'],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_tea_domain_model_product_tea.php
+++ b/Configuration/TCA/tx_tea_domain_model_product_tea.php
@@ -21,7 +21,7 @@ $tca = [
     'types' => [
         '1' => ['showitem' => '
             --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                title, description, image,
+                title, description, image, owner,
             --div--;LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.tabs.access,
                 --palette--;;access,
         '],
@@ -133,8 +133,23 @@ $tca = [
                 'foreign_table' => 'fe_groups',
             ],
         ],
+        'owner' => [
+            'exclude' => true,
+            'l10n_mode' => 'exclude',
+            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.owner',
+            'config' => [
+                'type' => 'group',
+                'allowed' => 'fe_users',
+                'default' => 0,
+                'size' => 1,
+                'minitems' => 0,
+                'maxitems' => 1,
+                'hideSuggest' => true,
+            ],
+        ],
     ],
 ];
+
 $typo3Version = new \TYPO3\CMS\Core\Information\Typo3Version();
 if ($typo3Version->getMajorVersion() < 12) {
     $tca = array_replace_recursive(

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -23,6 +23,10 @@
 				<source>Image</source>
 				<target>Bild</target>
 			</trans-unit>
+			<trans-unit id="tx_tea_domain_model_product_tea.owner">
+				<source>Website user who created this record</source>
+				<target>Website-Benutzer, der diesen Datensatz erstellt hat</target>
+			</trans-unit>
 			<trans-unit id="tx_tea_domain_model_product_tea.fe_group">
 				<source>Usergroup Access Rights</source>
 				<target>Zugriffsrechte für Benutzergruppen</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -18,6 +18,9 @@
 			<trans-unit id="tx_tea_domain_model_product_tea.image">
 				<source>Image</source>
 			</trans-unit>
+			<trans-unit id="tx_tea_domain_model_product_tea.owner">
+				<source>Website user who created this record</source>
+			</trans-unit>
 			<trans-unit id="tx_tea_domain_model_product_tea.fe_group">
 				<source>Usergroup Access Rights</source>
 			</trans-unit>

--- a/Tests/Functional/Domain/Repository/Fixtures/Product/Tea.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/Product/Tea.csv
@@ -1,8 +1,8 @@
 "tx_tea_domain_model_product_tea"
-,"uid","pid","title","description","image"
-,"1","1","Earl Grey","Fresh and hot.",0
-,"2","1","Assam","Dark and strong.",0
-,"3","1","Gunpowder","Bitter and very green.",1
+,"uid","pid","title","description","image","owner"
+,"1","1","Earl Grey","Fresh and hot.",0,2
+,"2","1","Assam","Dark and strong.",0,0
+,"3","1","Gunpowder","Bitter and very green.",1,0
 "sys_file_reference"
 ,"uid","pid","uid_foreign","tablenames","fieldname"
 ,"1","1","3","tx_tea_domain_model_product_tea","image"

--- a/Tests/Functional/Domain/Repository/Fixtures/Product/TeaWithOwner.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/Product/TeaWithOwner.csv
@@ -1,0 +1,3 @@
+"tx_tea_domain_model_product_tea"
+,"uid","pid","title","owner"
+,"1","1","Earl Grey",1

--- a/Tests/Functional/Domain/Repository/Fixtures/Product/TeaWithoutOwner.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/Product/TeaWithoutOwner.csv
@@ -1,0 +1,3 @@
+"tx_tea_domain_model_product_tea"
+,"uid","pid","title","owner"
+,"1","1","Earl Grey",0

--- a/Tests/Functional/Domain/Repository/Fixtures/Product/TwoTeasWithOwner.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/Product/TwoTeasWithOwner.csv
@@ -1,0 +1,4 @@
+"tx_tea_domain_model_product_tea"
+,"uid","pid","title","owner"
+,"1","1","Earl Grey",1
+,"2","1","Assam",1

--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -93,6 +93,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
 
         self::assertSame('Earl Grey', $model->getTitle());
         self::assertSame('Fresh and hot.', $model->getDescription());
+        self::assertSame(2, $model->getOwnerUid());
     }
 
     /**
@@ -132,5 +133,54 @@ final class TeaRepositoryTest extends FunctionalTestCase
 
         self::assertIsArray($databaseRow);
         self::assertSame($title, $databaseRow['title']);
+    }
+
+    /**
+     * @test
+     */
+    public function findByOwnerUidFindsTeaWithTheGivenOwnerUid(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithOwner.csv');
+
+        $result = $this->subject->findByOwnerUid(1);
+
+        self::assertCount(1, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function findByOwnerUidFindsIgnoresTeaWithNonMatchingOwnerUid(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithOwner.csv');
+
+        $result = $this->subject->findByOwnerUid(2);
+
+        self::assertCount(0, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function findByOwnerUidFindsIgnoresTeaWithZeroOwnerUid(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithoutOwner.csv');
+
+        $result = $this->subject->findByOwnerUid(1);
+
+        self::assertCount(0, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function findByOwnerUidSortsByTitleInAscendingOrder(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TwoTeasWithOwner.csv');
+
+        $result = $this->subject->findByOwnerUid(1);
+
+        $result->rewind();
+        self::assertSame(2, $result->current()->getUid());
     }
 }

--- a/Tests/Unit/Domain/Model/Product/TeaTest.php
+++ b/Tests/Unit/Domain/Model/Product/TeaTest.php
@@ -87,4 +87,23 @@ final class TeaTest extends UnitTestCase
 
         self::assertSame($model, $this->subject->getImage());
     }
+
+    /**
+     * @test
+     */
+    public function getOwnerUidInitiallyReturnsZero(): void
+    {
+        self::assertSame(0, $this->subject->getOwnerUid());
+    }
+
+    /**
+     * @test
+     */
+    public function setOwnerUidSetsOwnerUid(): void
+    {
+        $value = 123456;
+        $this->subject->setOwnerUid($value);
+
+        self::assertSame($value, $this->subject->getOwnerUid());
+    }
 }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,5 +1,8 @@
 CREATE TABLE tx_tea_domain_model_product_tea (
     title       varchar(255)     DEFAULT ''  NOT NULL,
     description varchar(2000)    DEFAULT ''  NOT NULL,
-    image       int(11) unsigned DEFAULT '0' NOT NULL
+    image       int(11) unsigned DEFAULT '0' NOT NULL,
+    owner       int(11) unsigned DEFAULT '0' NOT NULL,
+
+    KEY owner (owner)
 );


### PR DESCRIPTION
This is a pre-patch for adding a CRUD plugin for tea records.

This property contains only the UID of the owner FE user, but not a relation to a FE user model. This is because we neither have nor need a FE user model for the purposes of the CRUD plugin.