### PR TITLE
[TASK] Drop incorrectly placed `scope` HTML attribute

### DIFF
--- a/Resources/Private/Templates/Tea/Index.html
+++ b/Resources/Private/Templates/Tea/Index.html
@@ -21,7 +21,7 @@
             <tbody>
                 <f:for each="{teas}" as="tea">
                     <tr>
-                        <td scope="row">
+                        <td>
                             {tea.uid}
                         </td>
                         <td>


### PR DESCRIPTION
The `scope` attribute only makes sense for `th` elements, but not for `td` elements.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td