### PR TITLE
[TASK] Restructure the label keys

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -11,15 +11,15 @@
 				<source>Tea single view</source>
 				<target>Tee-Einzelansicht</target>
 			</trans-unit>
-			<trans-unit id="index.heading">
+			<trans-unit id="plugin.tea.heading">
 				<source>Our selection of assorted teas</source>
 				<target>Unsere Auswahl an erlesenen Tees</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.uid">
+			<trans-unit id="plugin.tea.property.uid">
 				<source>UID</source>
 				<target>UID</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.title">
+			<trans-unit id="plugin.tea.property.title">
 				<source>Title</source>
 				<target>Titel</target>
 			</trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -9,13 +9,13 @@
 			<trans-unit id="plugin.tea_show">
 				<source>Tea single view</source>
 			</trans-unit>
-			<trans-unit id="index.heading">
+			<trans-unit id="plugin.tea.heading">
 				<source>Our selection of assorted teas</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.uid">
+			<trans-unit id="plugin.tea.property.uid">
 				<source>UID</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.title">
+			<trans-unit id="plugin.tea.property.title">
 				<source>Title</source>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Templates/Tea/Index.html
+++ b/Resources/Private/Templates/Tea/Index.html
@@ -4,17 +4,17 @@
 
     <f:section name="main">
         <h2>
-            <f:translate key="index.heading"/>
+            <f:translate key="plugin.tea.heading"/>
         </h2>
 
         <table class="table">
             <thead>
                 <tr>
                     <th>
-                        <f:translate key="tx_tea_domain_model_product_tea.uid"/>
+                        <f:translate key="plugin.tea.property.uid"/>
                     </th>
                     <th>
-                        <f:translate key="tx_tea_domain_model_product_tea.title"/>
+                        <f:translate key="plugin.tea.property.title"/>
                     </th>
                 </tr>
             </thead>


### PR DESCRIPTION
Label keys should be specific to their context. This allows having different labels for the same thing in different contexts (e.g., having different headings for the tea title in the regular list view and the FE editor).

We take the plugin as the context here, which allows us to reuse labels between different actions of the same plugin (e.g., between the list view and single view).