### PR TITLE
[FEATURE] Add validation to the FE-editable tea properties

### DIFF
--- a/Classes/Domain/Model/Product/Tea.php
+++ b/Classes/Domain/Model/Product/Tea.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace TTN\Tea\Domain\Model\Product;
 
-use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
+use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
@@ -14,14 +14,21 @@ use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
  */
 class Tea extends AbstractEntity
 {
+    /**
+     * @Extbase\Validate("StringLength", options={"maximum": 255})
+     * @Extbase\Validate("NotEmpty")
+     */
     protected string $title = '';
 
+    /**
+     * @Extbase\Validate("StringLength", options={"maximum": 2000})
+     */
     protected string $description = '';
 
     /**
      * @var FileReference|null
      * @phpstan-var FileReference|LazyLoadingProxy|null
-     * @Lazy
+     * @Extbase\ORM\Lazy
      */
     protected $image;
 


### PR DESCRIPTION
The maximum length of the string fields ensures that the contents
fit within the limits of the corresponding DB columns.