### PR TITLE
[BUGFIX] Skip validation where validation makes no sense

### DIFF
--- a/Classes/Controller/FrontEndEditorController.php
+++ b/Classes/Controller/FrontEndEditorController.php
@@ -45,6 +45,9 @@ class FrontEndEditorController extends ActionController
         return $this->context->getPropertyFromAspect('frontend.user', 'id');
     }
 
+    /**
+     * @Extbase\IgnoreValidation("tea")
+     */
     public function editAction(Tea $tea): ResponseInterface
     {
         $this->checkIfUserIsOwner($tea);
@@ -73,6 +76,9 @@ class FrontEndEditorController extends ActionController
         return $this->redirect('index');
     }
 
+    /**
+     * @Extbase\IgnoreValidation("tea")
+     */
     public function newAction(?Tea $tea = null): ResponseInterface
     {
         // Note: We are using `makeInstance` here instead of `new` to allow for XCLASSing.


### PR DESCRIPTION
When creating a new tea record in the FE, or when editing one, the tea model provided to the form is not necessarily valid (and we need to accept invalid models if the following action rejects the model due to a valiation error).